### PR TITLE
Publisher can override default organisation FOI contact details for a dataset

### DIFF
--- a/app/controllers/datasets/foi_contacts_controller.rb
+++ b/app/controllers/datasets/foi_contacts_controller.rb
@@ -1,0 +1,47 @@
+class Datasets::FoiContactsController < ApplicationController
+  before_action :current_dataset
+
+  def new
+    @foi_contact = Dataset::FoiContact.new
+  end
+
+  def edit
+    @foi_contact = Dataset::FoiContact.new(
+      foi_name:  current_dataset.foi_name,
+      foi_email: current_dataset.foi_email,
+      foi_phone: current_dataset.foi_phone
+    )
+  end
+
+  def update
+    @foi_contact = Dataset::FoiContact.new(foi_contact_params)
+
+    if @foi_contact.valid?
+      @dataset.update(foi_contact_params)
+      redirect_to dataset_path(@dataset.uuid, @dataset.name)
+    else
+      render :edit
+    end
+  end
+
+  def create
+    @foi_contact = Dataset::FoiContact.new(foi_contact_params)
+
+    if @foi_contact.valid?
+      @dataset.update(foi_contact_params)
+      redirect_to new_dataset_licence_path(@dataset.uuid, @dataset.name)
+    else
+      render :new
+    end
+  end
+
+  private
+
+  def foi_contact_params
+    params.require(:dataset_foi_contact).permit(:foi_name, :foi_email, :foi_phone)
+  end
+
+  def current_dataset
+    @dataset ||= Dataset.find_by(uuid: params[:uuid])
+  end
+end

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -25,7 +25,7 @@ class DatasetsController < ApplicationController
     @dataset.organisation = current_user.primary_organisation
 
     if @dataset.save
-      redirect_to new_dataset_licence_path(@dataset.uuid, @dataset.name)
+      redirect_to new_dataset_foi_contact_path(@dataset.uuid, @dataset.name)
     else
       render :new
     end

--- a/app/helpers/datasets_helper.rb
+++ b/app/helpers/datasets_helper.rb
@@ -14,4 +14,8 @@ module DatasetsHelper
       ""
     end
   end
+
+  def foi_contact_details(dataset)
+    "#{dataset.foi_name} (#{dataset.foi_email})"
+  end
 end

--- a/app/models/dataset/foi_contact.rb
+++ b/app/models/dataset/foi_contact.rb
@@ -1,0 +1,10 @@
+class Dataset::FoiContact
+  include ActiveModel::Model
+
+  attr_accessor :foi_name, :foi_email, :foi_phone
+
+  EMAIL_FORMAT = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+
+  validates :foi_name, presence: true
+  validates :foi_email, presence: true, format: { with: EMAIL_FORMAT, message: "Please enter a valid email" }
+end

--- a/app/views/datasets/foi_contacts/edit.html.erb
+++ b/app/views/datasets/foi_contacts/edit.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title do %>
+  Edit contact details -
+<% end %>
+
+<% if @foi_contact.errors.any? %>
+  <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+    <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+      There was a problem
+    </h1>
+    <ul class="error-summary-list">
+      <% @foi_contact.errors.each do |attr, message| %>
+        <li>
+          <a href="#<%= attr.to_s %>_form_group">
+            <%= message %>
+          </a>
+          <span class="visuallyhidden">.</span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<h1 class="heading-large">Add contact details for this dataset</h1>
+
+<p>All datasets must have a contact to pass on queries directly to the publisher of the data or for a Freedom of Information Act (FOI) request.</p>
+
+<%= form_for @foi_contact, url: update_dataset_foi_contact_path, method: :patch do |f| %>
+  <div class="form-group">
+    <fieldset>
+      <legend class="visually-hidden">Add contact details for this dataset</legend>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_name',
+        label: 'Name:' %>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_email',
+        label: 'Email:' %>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_phone',
+        optional: true,
+        label: 'Phone number (optional):' %>
+    </fieldset>
+  </div>
+
+  <p><%= f.submit 'Save and continue', class: 'button' %></p>
+  <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>
+<% end %>

--- a/app/views/datasets/foi_contacts/new.html.erb
+++ b/app/views/datasets/foi_contacts/new.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title do %>
+  New contact details -
+<% end %>
+
+<% if @foi_contact.errors.any? %>
+  <div class="error-summary" role="group" aria-labelledby="error-summary-heading-example-1" tabindex="-1">
+    <h1 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+      There was a problem
+    </h1>
+    <ul class="error-summary-list">
+      <% @foi_contact.errors.each do |attr, message| %>
+        <li>
+          <a href="#<%= attr.to_s %>_form_group">
+            <%= message %>
+          </a>
+          <span class="visuallyhidden">.</span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<h1 class="heading-large">Add contact details for this dataset</h1>
+
+<p>All datasets must have a contact to pass on queries directly to the publisher of the data or for a Freedom of Information Act (FOI) request.</p>
+
+<%= form_for @foi_contact, url: create_dataset_foi_contact_path do |f| %>
+  <div class="form-group">
+    <fieldset>
+      <legend class="visually-hidden">Add contact details for this dataset</legend>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_name',
+        label: 'Name:' %>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_email',
+        label: 'Email:' %>
+
+      <%= dataset_field f, @foi_contact,
+        input_type: :text_field,
+        name: 'foi_phone',
+        optional: true,
+        label: 'Phone number (optional):' %>
+    </fieldset>
+  </div>
+
+  <p><%= f.submit 'Save and continue', class: 'button' %></p>
+  <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>
+<% end %>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -43,22 +43,30 @@
       <th class="dgu-checklist__heading">Title</th>
       <td><%= @dataset.title %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name), id: "edit_title" %>
         </td>
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Summary</th>
       <td><%= @dataset.summary %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name), id: "edit_summary" %>
         </td>
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Additional information</th>
       <td><%= @dataset.description %>
         <td class="dgu-checklist__actions">
-          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', edit_dataset_path(@dataset.uuid, @dataset.name), id: "edit_additional_info" %>
         </td>
+    </tr>
+    <tr>
+      <th class="dgu-checklist__heading">Contact Details</th>
+      <td><%= foi_contact_details(@dataset) %>
+        <td class="dgu-checklist__actions">
+          <%= link_to 'Change', edit_dataset_foi_contact_path(@dataset.uuid, @dataset.name), id: "edit_contact_details" %>
+        </td>
+      </td>
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Licence</th>
@@ -72,7 +80,7 @@
       </td>
       <td class="dgu-checklist__actions">
         <% if @dataset.licence %>
-          <%= link_to 'Change', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', edit_dataset_licence_path(@dataset.uuid, @dataset.name), id: "edit_licence" %>
         <% else %>
           <%= link_to 'Select', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>
         <% end %>
@@ -85,7 +93,7 @@
 
         <td class="dgu-checklist__actions">
           <% if @dataset.location1 %>
-            <%= link_to 'Change', edit_dataset_location_path(@dataset.uuid, @dataset.name) %>
+            <%= link_to 'Change', edit_dataset_location_path(@dataset.uuid, @dataset.name), id: "edit_location" %>
           <% else %>
             <%= link_to 'Add', edit_dataset_location_path(@dataset.uuid, @dataset.name) %>
           <% end %>
@@ -96,7 +104,7 @@
       <td><%= friendly_frequency(@dataset.frequency) if @dataset.frequency %></td>
       <td class="dgu-checklist__actions">
         <% if @dataset.frequency %>
-          <%= link_to 'Change', edit_dataset_frequency_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', edit_dataset_frequency_path(@dataset.uuid, @dataset.name), id: "edit_frequency" %>
         <% else %>
           <%= link_to 'Select', edit_dataset_frequency_path(@dataset.uuid, @dataset.name) %>
         <% end %>
@@ -116,7 +124,7 @@
       </td>
       <td class="dgu-checklist__actions">
         <% if @dataset.links.any? %>
-          <%= link_to 'Change', dataset_links_path(@dataset.uuid, @dataset.name) %>
+          <%= link_to 'Change', dataset_links_path(@dataset.uuid, @dataset.name), id: "edit_datalinks" %>
         <% else %>
           <%= link_to 'Add', new_dataset_link_path(@dataset.uuid, @dataset.name) %>
         <% end %>
@@ -124,15 +132,17 @@
     </tr>
     <tr>
       <th class="dgu-checklist__heading">Documentation</th>
-      <td><% @dataset.docs.each do |doc| %>
-        <%= link_to doc.name, doc.url %>
-      <% end %>
-      <td class="dgu-checklist__actions">
-        <% if @dataset.docs.any? %>
-          <%= link_to 'Change', dataset_docs_path(@dataset.uuid, @dataset.name) %>
-        <% else %>
-          <%= link_to 'Add', new_dataset_doc_path(@dataset.uuid, @dataset.name) %>
+      <td>
+        <% @dataset.docs.each do |doc| %>
+          <%= link_to doc.name, doc.url %>
         <% end %>
+        <td class="dgu-checklist__actions">
+          <% if @dataset.docs.any? %>
+            <%= link_to 'Change', dataset_docs_path(@dataset.uuid, @dataset.name), id: "edit_documentation" %>
+          <% else %>
+            <%= link_to 'Add', new_dataset_doc_path(@dataset.uuid, @dataset.name) %>
+          <% end %>
+        </td>
       </td>
     </tr>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,12 @@ Rails.application.routes.draw do
     post   ':uuid/*name/frequencies',    to: 'datasets/frequencies#create', as: 'create_dataset_frequency'
     patch  ':uuid/*name/frequency',      to: 'datasets/frequencies#update', as: 'update_dataset_frequency'
 
+    # contact details
+    get   ':uuid/*name/foi-contact/new',  to: 'datasets/foi_contacts#new',     as: 'new_dataset_foi_contact'
+    get   ':uuid/*name/foi-contact/edit', to: 'datasets/foi_contacts#edit',    as: 'edit_dataset_foi_contact'
+    post  ':uuid/*name/foi-contacts',     to: 'datasets/foi_contacts#create',  as: 'create_dataset_foi_contact'
+    patch ':uuid/*name/foi-contact',      to: 'datasets/foi_contacts#update',  as: 'update_dataset_foi_contact'
+
     # Datasets other
     get    ':uuid/*name/confirm_delete', to: 'datasets#confirm_delete',     as: 'confirm_delete_dataset'
     get    ':uuid/*name/quality',        to: 'datasets#quality',            as: 'dataset_quality'

--- a/db/migrate/20171117151037_add_contact_details_to_datasets.rb
+++ b/db/migrate/20171117151037_add_contact_details_to_datasets.rb
@@ -1,0 +1,7 @@
+class AddContactDetailsToDatasets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :foi_name, :string
+    add_column :datasets, :foi_phone, :string
+    add_column :datasets, :foi_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -117,6 +117,9 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.string "legacy_name"
     t.datetime "last_published_at"
     t.string "ckan_uuid"
+    t.string "foi_name"
+    t.string "foi_phone"
+    t.string "foi_email"
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -16,7 +16,7 @@ describe "dataset creation" do
       expect(page).to have_current_path("/tasks")
       click_link "Manage datasets"
       click_link "Create a dataset"
-      expect(page).to have_current_path("/datasets/new")
+      expect(page).to have_current_path(new_dataset_path)
       expect(page).to have_content("Create a dataset")
     end
 
@@ -31,7 +31,17 @@ describe "dataset creation" do
 
       expect(Dataset.where(title: "my test dataset").size).to eq(1)
 
-      # PAGE 2: Licence
+      # PAGE 2: Contact details
+      fill_in "dataset_foi_contact[foi_name]", with: "Jon Snow"
+      fill_in "dataset_foi_contact[foi_email]", with: "jonsnow@example.com"
+      fill_in "dataset_foi_contact[foi_phone]", with: "1234"
+      click_button "Save and continue"
+
+      expect(Dataset.last.foi_name).to eq("Jon Snow")
+      expect(Dataset.last.foi_email).to eq("jonsnow@example.com")
+      expect(Dataset.last.foi_phone).to eq("1234")
+
+      # PAGE 3: Licence
       choose option: "uk-ogl"
       click_button "Save and continue"
 
@@ -162,7 +172,7 @@ describe "starting a new draft with invalid inputs" do
     fill_in "dataset[summary]", with: "my test dataset summary"
     fill_in "dataset[description]", with: "my test dataset description"
     click_button "Save and continue"
-    expect(page).to have_content("Choose a licence")
+    expect(page).to have_content("Add contact details")
   end
 
   it "missing summary" do
@@ -177,7 +187,7 @@ describe "starting a new draft with invalid inputs" do
     fill_in "dataset[summary]", with: "my test dataset summary"
     fill_in "dataset[description]", with: "my test dataset description"
     click_button "Save and continue"
-    expect(page).to have_content("Choose a licence")
+    expect(page).to have_content("Add contact details")
   end
 
   it "missing both title and summary" do
@@ -191,7 +201,7 @@ describe "starting a new draft with invalid inputs" do
     fill_in "dataset[summary]", with: "my test dataset summary"
     fill_in "dataset[description]", with: "my test dataset description"
     click_button "Save and continue"
-    expect(page).to have_content("Choose a licence")
+    expect(page).to have_content("Add contact details")
   end
 end
 
@@ -205,11 +215,8 @@ describe "valid options for licence and area" do
     stub_request(:any, url).to_return(status: 200)
     user
     sign_in_user
-    visit new_dataset_path
-    fill_in "dataset[title]", with: "my test dataset"
-    fill_in "dataset[summary]", with: "my test dataset summary"
-    fill_in "dataset[description]", with: "my test dataset description"
-    click_button "Save and continue"
+    dataset = FactoryGirl.create(:dataset, organisation: land_registry)
+    visit new_dataset_licence_path(dataset.uuid, dataset.name)
   end
 
   context "when selecting license type" do

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -1,16 +1,5 @@
 def click_change(property)
-  properties = {
-    :title => 0,
-    :summary => 1,
-    :additional_info => 2,
-    :licence => 3,
-    :location => 4,
-    :frequency => 5,
-    :datalinks => 6,
-    :documentation => 7
-  }
-  index = properties[property]
-  all(:link, "Change")[index].click
+  find("#edit_#{property}").click
 end
 
 def click_dataset(dataset)


### PR DESCRIPTION
Trello: https://trello.com/c/wMpJMdwK/112-allow-publisher-to-override-default-contact-details-per-dataset

Each Publisher Organisation has contact details. These are shown on the dataset page.
Datasets may have more specific people to contact - Publishers should be able to add these as part of workflow.

## todo

* [x] add email validation
* [x] tests