### PR TITLE
Remove column removal patches

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -37,18 +37,6 @@ class Dataset < ApplicationRecord
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, ->{ where(status: "published") }
 
-  def self.columns
-    super.reject { |c| c.name == "last_published_at" }
-  end
-
-  def self.columns
-    super.reject { |c| c.name == "ckan_uuid" }
-  end
-
-  def self.columns
-    super.reject { |c| c.name == "stage" }
-  end
-
   def is_readonly?
     if persisted? && self.harvested?
       errors[:base] << 'Harvested datasets cannot be modified.'


### PR DESCRIPTION
ActiveRecord caches table columns, and uses this cache to build INSERT statements. Even if the code is not touching that column, ActiveRecord will still attempt to set it to NULL when saving models.

https://blog.codeship.com/rails-migrations-zero-downtime/