### PR TITLE
User can publish dataset with no datafile

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -31,7 +31,6 @@ class Dataset < ApplicationRecord
   validates :licence, presence: true, if: :published?
   validates :licence_other, presence: true, if: lambda { licence == 'other' }
 
-  validate  :published_dataset_must_have_datafiles_validation
   validate  :is_readonly?, on: :update
 
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
@@ -115,12 +114,6 @@ class Dataset < ApplicationRecord
 
   def prevent_if_published
     raise 'published datasets cannot be deleted' if published?
-  end
-
-  def published_dataset_must_have_datafiles_validation
-    if self.published? && self.links.empty?
-      errors.add(:links, "You must add at least one link")
-    end
   end
 
   def daily?

--- a/spec/features/datafile_spec.rb
+++ b/spec/features/datafile_spec.rb
@@ -1,15 +1,20 @@
 require "rails_helper"
 
 describe 'datafiles' do
-  set_up_models
+  let(:land) { FactoryGirl.create(:organisation) }
+  let(:user) { FactoryGirl.create(:user, primary_organisation: land) }
+  let(:published_dataset) { FactoryGirl.create(:dataset,
+                                               organisation: land,
+                                               status: "published",
+                                               links: [FactoryGirl.create(:link)],
+                                               docs: [FactoryGirl.create(:doc)],
+                                               creator: user,
+                                               owner: user) }
 
   before(:each) do
     user
     sign_in_user
-    build_datasets
-
-    click_link 'Manage datasets'
-    click_dataset(published_dataset)
+    visit dataset_path(published_dataset.uuid, published_dataset.name)
   end
 
   it "should be able to add a new file" do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -51,7 +51,6 @@ describe Dataset do
 
     expect(dataset.errors[:licence]).to include("Please select a licence for your dataset")
     expect(dataset.errors[:frequency]).to include("Please indicate how often this dataset is updated")
-    expect(dataset.errors[:links]).to include("You must add at least one link")
   end
 
   it "can pass strict validation when publishing" do

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -16,38 +16,3 @@ end
 def click_dataset(dataset)
   find(:xpath, "//a[@href='#{dataset_path(dataset.uuid, dataset.name)}']").click
 end
-
-def set_up_models
-
-    let(:land) { FactoryGirl.create(:organisation) }
-    let(:user) { FactoryGirl.create(:user, primary_organisation: land) }
-
-    let(:published_dataset) { FactoryGirl.create(:dataset,
-                                                  organisation: land,
-                                                  status: "published",
-                                                  links: [FactoryGirl.create(:link)],
-                                                  docs: [FactoryGirl.create(:doc)],
-                                                  creator: user,
-                                                  owner: user) }
-
-    let(:unpublished_dataset) { FactoryGirl.create(:dataset,
-                                                    organisation: land,
-                                                    status: "draft",
-                                                    links: [FactoryGirl.create(:link)],
-                                                    docs: [FactoryGirl.create(:doc)],
-                                                    creator: user,
-                                                    owner: user ) }
-
-
-    let(:unfinished_dataset) { FactoryGirl.create(:dataset,
-                                                   organisation: land,
-                                                   creator: user,
-                                                   owner: user) }
-
-end
-
-def build_datasets
-  published_dataset
-  unpublished_dataset
-  unfinished_dataset
-end


### PR DESCRIPTION
A publisher should be able to publish a dataset with no datafile.

https://trello.com/c/Jb4ablla/70-as-a-user-of-publish-i-can-publish-a-dataset-that-has-no-datafiles