### PR TITLE
Revert "Add AdditionalInfo Model (#462)"

### DIFF
--- a/app/models/additional_info.rb
+++ b/app/models/additional_info.rb
@@ -1,2 +1,0 @@
-class AdditionalInfo < Datafile
-end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,7 +21,6 @@ class Dataset < ApplicationRecord
 
   has_many :links
   has_many :docs
-  has_many :additional_infos
   has_one :inspire_dataset
 
   validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never) },
@@ -71,9 +70,7 @@ class Dataset < ApplicationRecord
              :harvested, :uuid],
       include: {
         organisation: {},
-        docs: {},
-        links: {},
-        additional_infos: {},
+        datafiles: {},
         inspire_dataset: {}
       }
     )

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -50,8 +50,8 @@ class Legacy::DatasetImportService
   end
 
   def create_additional_info_datafiles(dataset)
-    Array(legacy_dataset['additional_resources']).each do |resource|
-      datafile = AdditionalInfo.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
+    Array(@legacy_dataset['additional_resources']).each do |resource|
+      datafile = Doc.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
       base_attributes = create_datafile_base_attributes(resource, dataset)
 
       datafile.assign_attributes(base_attributes)
@@ -60,7 +60,7 @@ class Legacy::DatasetImportService
   end
 
   def create_non_timeseries_datafiles(dataset)
-    Array(legacy_dataset['individual_resources']).each do |resource|
+    Array(@legacy_dataset['individual_resources']).each do |resource|
       datafile = Doc.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
       base_attributes = create_datafile_base_attributes(resource, dataset)
 
@@ -70,7 +70,7 @@ class Legacy::DatasetImportService
   end
 
   def create_timeseries_datafiles(dataset)
-    Array(legacy_dataset['timeseries_resources']).each do |resource|
+    Array(@legacy_dataset['timeseries_resources']).each do |resource|
       datafile = Link.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
       base_attributes = create_datafile_base_attributes(resource, dataset)
       date_attributes = create_datafile_date_attributes(resource)

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -34,7 +34,47 @@
     "revision_id": "197dfecf-32e7-4666-b08a-2e35a9536b16",
     "date_released": "15/9/2011",
     "theme-primary": "Government",
-    "resources": [],
+    "resources": [
+      {
+        "hash": "",
+        "description": "Resource 1 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file.csv",
+        "date": "2017",
+        "format": "CSV",
+        "date": "3/2016",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+      },
+      {
+        "hash": "",
+        "description": "Resource 2 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file.html",
+        "format": "html",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+      }
+    ],
+    "timeseries_resources": [
+      {
+        "hash": "",
+        "description": "Resource 1 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file_1.csv",
+        "date": "3/2016",
+        "format": "CSV",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+      }
+    ],
+    "additional_resources": [
+      {
+        "hash": "",
+        "description": "Resource 2 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file.html",
+        "format": "html",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+      }
+    ],
     "tags": [
       {
         "vocabulary_id": null,

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -54,20 +54,35 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.secondary_theme_id).to eql(678)
     end
 
+    it "creates the datafiles for the imported dataset" do
+      described_class.new(legacy_dataset, orgs_cache, themes_cache).run
+      imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
+      imported_datafiles = imported_dataset.datafiles
+      first_imported_datafile = imported_datafiles.first
+      first_resource = legacy_dataset["resources"][0]
+
+      expect(imported_datafiles.count).to eql(2)
+      expect(first_imported_datafile.uuid).to eql(first_resource["id"])
+      expect(first_imported_datafile.format).to eql(first_resource["format"])
+      expect(first_imported_datafile.name).to eql(first_resource["description"])
+      expect(first_imported_datafile.created_at).to eql(imported_dataset.created_at)
+      expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
+      expect(first_imported_datafile.start_date).to eql(Date.parse(first_resource["date"]).beginning_of_month)
+      expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
+    end
+
     it "builds a dataset from a non timeseries legacy dataset" do
       Legacy::DatasetImportService.new(non_timeseries_legacy_dataset, orgs_cache, themes_cache).run
       expect(Dataset.last.frequency).to eq('never')
-      expect(Dataset.last.links.count).to eq(0)
-      expect(Dataset.last.docs.count).to eq(3)
-      expect(Dataset.last.additional_infos.count).to eq(1)
+      expect(Dataset.last.docs.count).to eq(4)
     end
 
     it "builds a dataset from a timeseries legacy dataset" do
       Legacy::DatasetImportService.new(timeseries_legacy_dataset, orgs_cache, themes_cache).run
       expect(Dataset.last.frequency).to eq('monthly')
-      expect(Dataset.last.docs.count).to eq(0)
+
       expect(Dataset.last.links.count).to eq(3)
-      expect(Dataset.last.additional_infos.count).to eq(1)
+      expect(Dataset.last.docs.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
This reverts commit a54347eaf2b7f9bc6efc7ef6b892a04e1f82e27d.

There appears to be an issue when trying to import legacy datasets on Publish Staging (out of memory). These changes can be reinstated once fixed. A PR to revert corresponding changes on Find can be found here - https://github.com/alphagov/datagovuk_find/pull/325