### PR TITLE
Map dataset :legacy_name in ElasticSearch index

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -61,7 +61,7 @@ class Dataset < ApplicationRecord
   # dataset.
   def as_indexed_json(_options={})
     as_json(
-      only: [:name, :title, :summary, :description,
+      only: [:name, :legacy_name, :title, :summary, :description,
              :foi_name, :foi_email, :foi_phone, :foi_web,
              :contact_name, :contact_email, :contact_phone,
              :location1, :location2, :location3,

--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -52,6 +52,10 @@ class DatasetsIndexerService
             type: 'string',
             index: 'not_analyzed'
           },
+          legacy_name: {
+            type: 'string',
+            index: 'not_analyzed'
+          },
           uuid: {
             type: 'string',
             index: 'not_analyzed'


### PR DESCRIPTION
This PR makes sure we include the dataset `legacy_name` in the ES index, so we can use it in Find to redirect from legacy URLs to the new ones.

Trello: https://trello.com/c/HbtA8f6l/165-make-legacy-dataset-urls-work-in-find-l

PR in FIND: https://github.com/alphagov/datagovuk_find/pull/327.