### PR TITLE
Remove unnecessary require

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,7 +2,6 @@ require_relative 'boot'
 
 require "rails"
 # Pick the frameworks you want:
-require "dotenv/load" if Rails.env.development? || Rails.env.test?
 require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"


### PR DESCRIPTION
Any rake task ran on staging environment with `RAILS_ENV=test` fails because the `dotenv` gem is only installed on test and development environments.

And actually, we don't even need that for `dotenv` to work.

https://github.com/bkeepers/dotenv