### PR TITLE
Add legacy_name to ES index mapping

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -6,6 +6,10 @@ class DatasetsIndexerService
           type: 'string',
           index: 'not_analyzed'
         },
+        legacy_name: {
+          type: 'string',
+          index: 'not_analyzed'
+        },
         uuid: {
           type: 'string',
           index: 'not_analyzed'

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe DatasetsIndexerService do
+  it "has the correct index mappings" do
+    expected_mappings = {
+      dataset: {
+        properties: {
+          name: {
+            type: 'string',
+            index: 'not_analyzed'
+          },
+          legacy_name: {
+            type: 'string',
+            index: 'not_analyzed'
+          },
+          uuid: {
+            type: 'string',
+            index: 'not_analyzed'
+          },
+          location1: {
+            type: 'string',
+            fields: {
+              raw: {
+                type: 'string',
+                index: 'not_analyzed'
+              }
+            }
+          },
+          organisation: {
+            type: 'nested',
+            properties: {
+              title: {
+                type: 'string',
+                fields: {
+                  raw: {
+                    type: 'string',
+                    index: 'not_analyzed'
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    expect(DatasetsIndexerService::INDEX_MAPPING).to eql(expected_mappings)
+  end
+end


### PR DESCRIPTION
Accidentally removed the `legacy_name` from the mappings when I did this refactor here https://github.com/alphagov/datagovuk_publish/pull/467/files.

I added a test so it doesn't happen again :)