### PR TITLE
Set last_updated_at on `Dataset#publish!`

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -50,7 +50,7 @@ class Dataset < ApplicationRecord
   def publish!
     if publishable?
       transaction do
-        set_first_publication_date
+        set_timestamps
         self.published!
         send_to_search_index
       end
@@ -157,7 +157,16 @@ class Dataset < ApplicationRecord
     PublishingWorker.perform_async(self.id)
   end
 
+  def set_timestamps
+    set_first_publication_date
+    set_last_updated_date
+  end
+
   def set_first_publication_date
     self.published_date ||= Time.now
+  end
+
+  def set_last_updated_date
+    self.last_updated_at = Time.now
   end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -101,4 +101,14 @@ describe Dataset do
 
     expect(dataset.published_date).to eq publication_date
   end
+
+  it "sets a last_updated_at timestamp when published" do
+    last_updated_at = Time.now
+    allow(Time).to receive(:now).and_return(last_updated_at)
+    dataset = FactoryGirl.create(:dataset, links: [FactoryGirl.create(:link)])
+    dataset.save
+    dataset.publish!
+
+    expect(dataset.last_updated_at).to eq last_updated_at
+  end
 end


### PR DESCRIPTION
Set last_updated_at on `Dataset#publish!`. Its absence is currently causing FIND to error when a user visits a dataset.