### PR TITLE
import from resources only

### DIFF
--- a/app/models/datafile.rb
+++ b/app/models/datafile.rb
@@ -2,12 +2,14 @@ require 'securerandom'
 require 'validators/url_validator'
 
 class Datafile < ApplicationRecord
+
   belongs_to :dataset
 
   validates :name, presence: true
   validates_with UrlValidator
 
   before_save :set_uuid
+
 
   def set_uuid
     if self.uuid.blank?

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -23,7 +23,7 @@ class Dataset < ApplicationRecord
   has_many :docs
   has_one :inspire_dataset
 
-  validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never) },
+  validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
                         allow_nil: true # To allow creation before setting this value
   validates :title, presence: true, format: { with: TITLE_FORMAT }
   validates :summary, presence: true

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,21 +1,18 @@
 class Link < Datafile
-  attr_accessor :day, :month, :year
 
-  before_save :set_date
+  before_save :set_end_date
 
-  validate  :validate_date_input, unless: ->{ dataset.never? }
+  validate  :validate_date_input, unless: ->{ dataset.never? || start_date.nil? }
   validates :quarter, presence: true, if: ->{ dataset.quarterly? }
 
-  def dates
-    {
-      day:   day   || end_date&.day,
-      month: month || end_date&.month,
-      year:  year  || end_date&.year
-    }.with_indifferent_access
+  def start_date
+    self['start_date']
   end
 
-  def set_date
-    self.end_date = compute_date
+  def set_end_date
+    if start_date
+      self.end_date = compute_date
+    end
   end
 
   private
@@ -29,13 +26,11 @@ class Link < Datafile
   end
 
   def daily_date
-    Date.new(year.to_i,
-             month.to_i,
-             day.to_i)
+    Date.new(start_date.year.to_i, start_date.month.to_i, start_date.day)
   end
 
   def monthly_date
-    Date.new(year.to_i, month.to_i).end_of_month
+    Date.new(start_date.year.to_i, start_date.month.to_i).end_of_month
   end
 
   def quarterly_date
@@ -43,7 +38,7 @@ class Link < Datafile
   end
 
   def quarter_to_date
-    year_start = Date.new(year.to_i).beginning_of_year
+    year_start = Date.new(start_date.year.to_i).beginning_of_year
     year_start + (quarter_offset - 1).months
   end
 
@@ -52,11 +47,11 @@ class Link < Datafile
   end
 
   def yearly_date
-    Date.new(year.to_i).end_of_year
+    Date.new(start_date.year.to_i).end_of_year
   end
 
   def financial_yearly_date
-    Date.new(year.to_i + 1).end_of_quarter
+    Date.new(start_date.year.to_i + 1).end_of_quarter
   end
 
   def validate_date_input
@@ -72,13 +67,13 @@ class Link < Datafile
   end
 
   def validate_month
-    if month.to_i < 1 || month.to_i > 12
+    if start_date.month.to_i < 1 || start_date.month.to_i > 12
       errors.add(:month, 'Please enter a valid month')
     end
   end
 
   def validate_year
-    if year.to_i < 1000 || year.to_i > 5000
+    if start_date.year.to_i < 1000 || start_date.year.to_i > 5000
       errors.add(:year, 'Please enter a valid year')
     end
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,18 +1,21 @@
 class Link < Datafile
-
+  attr_accessor :day, :month, :year
+  
   before_save :set_end_date
 
-  validate  :validate_date_input, unless: ->{ dataset.never? || start_date.nil? }
+  validate  :validate_date_input, unless: ->{ dataset.never? }
   validates :quarter, presence: true, if: ->{ dataset.quarterly? }
 
-  def start_date
-    self['start_date']
+  def dates
+    {
+      day:   day   || end_date&.day,
+      month: month || end_date&.month,
+      year:  year  || end_date&.year
+    }.with_indifferent_access
   end
 
   def set_end_date
-    if start_date
-      self.end_date = compute_date
-    end
+    self.end_date = compute_date
   end
 
   private
@@ -26,11 +29,11 @@ class Link < Datafile
   end
 
   def daily_date
-    Date.new(start_date.year.to_i, start_date.month.to_i, start_date.day)
+    Date.new(year.to_i, month.to_i, day.to_i)
   end
 
   def monthly_date
-    Date.new(start_date.year.to_i, start_date.month.to_i).end_of_month
+    Date.new(year.to_i, month.to_i).end_of_month
   end
 
   def quarterly_date
@@ -38,7 +41,7 @@ class Link < Datafile
   end
 
   def quarter_to_date
-    year_start = Date.new(start_date.year.to_i).beginning_of_year
+    year_start = Date.new(year.to_i).beginning_of_year
     year_start + (quarter_offset - 1).months
   end
 
@@ -47,11 +50,11 @@ class Link < Datafile
   end
 
   def yearly_date
-    Date.new(start_date.year.to_i).end_of_year
+    Date.new(year.to_i).end_of_year
   end
 
   def financial_yearly_date
-    Date.new(start_date.year.to_i + 1).end_of_quarter
+    Date.new(year.to_i + 1).end_of_quarter
   end
 
   def validate_date_input
@@ -67,13 +70,13 @@ class Link < Datafile
   end
 
   def validate_month
-    if start_date.month.to_i < 1 || start_date.month.to_i > 12
+    if month.to_i < 1 || month.to_i > 12
       errors.add(:month, 'Please enter a valid month')
     end
   end
 
   def validate_year
-    if start_date.year.to_i < 1000 || start_date.year.to_i > 5000
+    if year.to_i < 1000 || year.to_i > 5000
       errors.add(:year, 'Please enter a valid year')
     end
   end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -54,7 +54,7 @@ class Legacy::DatasetImportService
     legacy_datafiles.each do |legacy_datafile|
       datafile = Link.find_or_create_by(url: legacy_datafile["url"], dataset_id: dataset.id)
       base_attributes = create_resource_base_attributes(legacy_datafile, dataset)
-      date_attributes = create_datafile_date_attributes(legacy_datafile, dataset.frequency)
+      date_attributes = create_datafile_date_attributes(legacy_datafile)
       datafile.assign_attributes(base_attributes)
       datafile.assign_attributes(date_attributes)
       datafile.save!(validate: false)
@@ -158,39 +158,53 @@ class Legacy::DatasetImportService
     get_extra("harvest_object_id").present?
   end
 
-  def create_datafile_date_attributes(legacy_datafile, frequency)
-    if legacy_datafile["date"].present?
-      start_date = get_start_date(legacy_datafile["date"], frequency)
+  def create_datafile_date_attributes(resource)
+    if resource["date"].blank?
+      {}
     else
-      start_date = nil
+      dates = get_start_end_date(resource["date"])
+      start_date = Date.parse(dates[0])
+      end_date = Date.parse(dates[1])
+
+      {
+        start_date: start_date,
+        end_date: end_date,
+        day: end_date.day,
+        month: end_date.month,
+        year: end_date.year
+      }
     end
-    { start_date: start_date }
   end
 
   # Given a lax legacy date string, try and build a proper
   # date string that we can import
-  def get_start_date(date_string, frequency)
-    date =
-      (date_string.length == 4) ? "1/1/#{date_string}" : date_string
-    begin
-      date_object = Date.parse(date)
-    rescue
-      return nil
+  def get_start_end_date(date_string)
+    # eg "1983"
+    if date_string.length == 4
+      return calculate_dates_for_year(date_string.to_i)
     end
-
-    case frequency
-      when 'annually'
-        Date.new(date_object.year)
-      when 'monthly'
-        Date.new(date_object.year, date_object.month)
-      when 'quarterly'
-        calculate_quarterly_dates(date_object)
-      else
-        date_object
-    end
-
+     # eg "1983/02/12"
+     parts = date_string.split("/")
+   if parts.length == 3
+     return [date_string, date_string]
+   end
+     # eg "1983/02"
+   if parts and parts.length == 2
+     return calculate_dates_for_month(parts[0].to_i, parts[1].to_i)
+   end
+     ["", ""]
   end
 
+  # Date helpers
+
+  def calculate_dates_for_month(month, year)
+    days = Time.days_in_month(month, year)
+    ["1/#{month}/#{year}", "#{days}/#{month}/#{year}"]
+  end
+
+  def calculate_dates_for_year(year)
+    ["1/1/#{year}", "31/12/#{year}"]
+  end
 
   private
 

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -83,6 +83,24 @@ class Legacy::DatasetImportService
     }
   end
 
+  def create_datafile_date_attributes(resource)
+    if resource["date"].blank?
+      {}
+    else
+      dates = get_start_end_date(resource["date"])
+      start_date = Date.parse(dates[0])
+      end_date = Date.parse(dates[1])
+
+      {
+        start_date: start_date,
+        end_date: end_date,
+        day: end_date.day,
+        month: end_date.month,
+        year: end_date.year
+      }
+    end
+  end
+
   def datafile_name(resource)
     resource['description'].strip == '' ? 'No name specified' : resource['description']
   end
@@ -156,24 +174,6 @@ class Legacy::DatasetImportService
 
   def harvested?
     get_extra("harvest_object_id").present?
-  end
-
-  def create_datafile_date_attributes(resource)
-    if resource["date"].blank?
-      {}
-    else
-      dates = get_start_end_date(resource["date"])
-      start_date = Date.parse(dates[0])
-      end_date = Date.parse(dates[1])
-
-      {
-        start_date: start_date,
-        end_date: end_date,
-        day: end_date.day,
-        month: end_date.month,
-        year: end_date.year
-      }
-    end
   end
 
   # Given a lax legacy date string, try and build a proper

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -160,7 +160,8 @@ class Legacy::DatasetImportService
     new_frequency = {
       "annual" => "annually",
       "quarterly" => "quarterly",
-      "monthly" => "monthly"
+      "monthly" => "monthly",
+      "other" => "irregular"
     }[freq] || "never"
 
     new_frequency

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -10,7 +10,7 @@ class Legacy::DatasetImportService
   def run
     update_or_create_dataset
     create_inspire_dataset(dataset.id) if dataset.dataset_type == 'inspire'
-    create_datafiles(dataset)
+    create_resources(dataset)
   end
 
   def update_or_create_dataset
@@ -43,66 +43,43 @@ class Legacy::DatasetImportService
     dataset.save!(validate: false)
   end
 
+  def create_resources(dataset)
+    create_datafiles(dataset)
+    create_documents(dataset)
+  end
+
   def create_datafiles(dataset)
-    create_timeseries_datafiles(dataset)
-    create_non_timeseries_datafiles(dataset)
-    create_additional_info_datafiles(dataset)
-  end
-
-  def create_additional_info_datafiles(dataset)
-    Array(@legacy_dataset['additional_resources']).each do |resource|
-      datafile = Doc.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
-      base_attributes = create_datafile_base_attributes(resource, dataset)
-
-      datafile.assign_attributes(base_attributes)
-      datafile.save!(validate: false)
-    end
-  end
-
-  def create_non_timeseries_datafiles(dataset)
-    Array(@legacy_dataset['individual_resources']).each do |resource|
-      datafile = Doc.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
-      base_attributes = create_datafile_base_attributes(resource, dataset)
-
-      datafile.assign_attributes(base_attributes)
-      datafile.save!(validate: false)
-    end
-  end
-
-  def create_timeseries_datafiles(dataset)
-    Array(@legacy_dataset['timeseries_resources']).each do |resource|
-      datafile = Link.find_or_create_by(url: resource["url"], dataset_id: dataset.id)
-      base_attributes = create_datafile_base_attributes(resource, dataset)
-      date_attributes = create_datafile_date_attributes(resource)
-
+    resources = Array(@legacy_dataset['resources'])
+    legacy_datafiles = resources.select{ |resource| resource['resource_type'] == 'file'}
+    legacy_datafiles.each do |legacy_datafile|
+      datafile = Link.find_or_create_by(url: legacy_datafile["url"], dataset_id: dataset.id)
+      base_attributes = create_resource_base_attributes(legacy_datafile, dataset)
+      date_attributes = create_datafile_date_attributes(legacy_datafile, dataset.frequency)
       datafile.assign_attributes(base_attributes)
       datafile.assign_attributes(date_attributes)
-
       datafile.save!(validate: false)
     end
   end
 
-  def create_datafile_base_attributes(resource, dataset)
+  def create_documents(dataset)
+    resources = Array(@legacy_dataset['resources'])
+    legacy_documents = resources.select{ |resource| resource['resource_type'] == 'documentation'}
+    legacy_documents.each do |legacy_document|
+      document = Doc.find_or_create_by(url: legacy_document["url"], dataset_id: dataset.id)
+      base_attributes = create_resource_base_attributes(legacy_document, dataset)
+
+      document.assign_attributes(base_attributes)
+      document.save!(validate: false)
+    end
+  end
+
+  def create_resource_base_attributes(resource, dataset)
     {
       uuid: resource["id"],
       format: resource["format"],
       name: datafile_name(resource),
       created_at: dataset.created_at,
       updated_at: dataset.last_updated_at
-    }
-  end
-
-  def create_datafile_date_attributes(resource)
-    dates = get_start_end_date(resource["date"])
-    start_date = Date.parse(dates[0])
-    end_date = Date.parse(dates[1])
-
-    {
-      start_date: start_date,
-      end_date: end_date,
-      day: end_date.day,
-      month: end_date.month,
-      year: end_date.year
     }
   end
 
@@ -181,41 +158,45 @@ class Legacy::DatasetImportService
     get_extra("harvest_object_id").present?
   end
 
+  def create_datafile_date_attributes(legacy_datafile, frequency)
+    if legacy_datafile["date"].present?
+      start_date = get_start_date(legacy_datafile["date"], frequency)
+    else
+      start_date = nil
+    end
+    { start_date: start_date }
+  end
+
   # Given a lax legacy date string, try and build a proper
   # date string that we can import
-  def get_start_end_date(date_string)
-    return ["", ""] if !date_string
-
-    # eg "1983"
-    if date_string.length == 4
-      return calculate_dates_for_year(date_string.to_i)
+  def get_start_date(date_string, frequency)
+    date =
+      (date_string.length == 4) ? "1/1/#{date_string}" : date_string
+    begin
+      date_object = Date.parse(date)
+    rescue
+      return nil
     end
 
-    # eg "1983/02/12"
-    parts = date_string.split("/")
-    if parts.length == 3
-      return [date_string, date_string]
+    case frequency
+      when 'annually'
+        Date.new(date_object.year)
+      when 'monthly'
+        Date.new(date_object.year, date_object.month)
+      when 'quarterly'
+        calculate_quarterly_dates(date_object)
+      else
+        date_object
     end
 
-    # eg "1983/02"
-    if parts and parts.length == 2
-      return calculate_dates_for_month(parts[0].to_i, parts[1].to_i)
-    end
-
-    ["", ""]
   end
 
-  # Date helpers
-  def calculate_dates_for_month(month, year)
-    days = Time.days_in_month(month, year)
-    ["1/#{month}/#{year}", "#{days}/#{month}/#{year}"]
-  end
-
-  def calculate_dates_for_year(year)
-    ["1/1/#{year}", "31/12/#{year}"]
-  end
 
   private
+
+  def calculate_quarterly_dates(date_object)
+    Date.new(date_object.year, 1+(date_object.month -1 )/4*4)
+  end
 
   def dataset
     @dataset ||= Dataset.find_or_create_by(uuid: legacy_dataset["id"])

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -39,11 +39,11 @@
         "hash": "",
         "description": "Resource 1 description",
         "created": "2017-12-04T09:35:25.928982",
-        "url": "https://example.com/file.csv",
-        "date": "2017",
+        "url": "https://example.com/file_1.csv",
         "format": "CSV",
         "date": "3/2016",
-        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e719",
+        "resource_type": "file"
       },
       {
         "hash": "",
@@ -51,7 +51,8 @@
         "created": "2017-12-04T09:35:25.928982",
         "url": "https://example.com/file.html",
         "format": "html",
-        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
+        "resource_type": "documentation"
       }
     ],
     "timeseries_resources": [
@@ -60,9 +61,10 @@
         "description": "Resource 1 description",
         "created": "2017-12-04T09:35:25.928982",
         "url": "https://example.com/file_1.csv",
-        "date": "3/2016",
+        "date": "2017",
         "format": "CSV",
-        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e719",
+        "resource_type": "file"
       }
     ],
     "additional_resources": [
@@ -72,7 +74,8 @@
         "created": "2017-12-04T09:35:25.928982",
         "url": "https://example.com/file.html",
         "format": "html",
-        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
+        "resource_type": "documentation"
       }
     ],
     "tags": [

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -74,14 +74,14 @@ describe Legacy::DatasetImportService do
     it "builds a dataset from a non timeseries legacy dataset" do
       Legacy::DatasetImportService.new(non_timeseries_legacy_dataset, orgs_cache, themes_cache).run
       expect(Dataset.last.frequency).to eq('never')
-      expect(Dataset.last.docs.count).to eq(4)
+      expect(Dataset.last.docs.count).to eq(1)
     end
 
     it "builds a dataset from a timeseries legacy dataset" do
       Legacy::DatasetImportService.new(timeseries_legacy_dataset, orgs_cache, themes_cache).run
       expect(Dataset.last.frequency).to eq('monthly')
 
-      expect(Dataset.last.links.count).to eq(3)
+      expect(Dataset.last.links.count).to eq(1)
       expect(Dataset.last.docs.count).to eq(1)
     end
   end


### PR DESCRIPTION
This PR:

- add the option of `irregular frequency` for imported datasets
- imports from `package['resources']`, rather than importing from `timeseries_resources`, `additional_resources` etc.