### PR TITLE
Set dates consistently across legacy and publish datafiles

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -4,6 +4,7 @@ class Link < Datafile
   # Some legacy datafiles have invalid dates (e.g. 31/06/15).
   # When this occurs the date attributes are empty, therefore we cannot invoke this call-back
   before_save :set_end_date, unless: ->{ year.nil? }
+  before_save :set_start_date, unless: ->{ year.nil? }
 
   validate  :validate_date_input, unless: ->{ dataset.never? }
   validates :quarter, presence: true, if: ->{ dataset.quarterly? }
@@ -17,29 +18,41 @@ class Link < Datafile
   end
 
   def set_end_date
-    self.end_date = compute_date
+    self.end_date = compute_date(:end)
+  end
+
+  def set_start_date
+    self.start_date = compute_date(:start)
   end
 
   private
 
-  def compute_date
-    return daily_date            if dataset.daily?
-    return monthly_date          if dataset.monthly?
-    return quarterly_date        if dataset.quarterly?
-    return yearly_date           if dataset.annually?
-    return financial_yearly_date if dataset.financial_yearly?
+  def compute_date(date_type)
+    return daily_date                       if dataset.daily?
+    return monthly_date(date_type)          if dataset.monthly?
+    return quarterly_date(date_type)        if dataset.quarterly?
+    return yearly_date(date_type)           if dataset.annually?
+    return financial_yearly_date(date_type) if dataset.financial_yearly?
   end
 
   def daily_date
     Date.new(year.to_i, month.to_i, day.to_i)
   end
 
-  def monthly_date
-    Date.new(year.to_i, month.to_i).end_of_month
+  def monthly_date(date_type)
+    if date_type == :end
+      Date.new(year.to_i, month.to_i).end_of_month
+    else
+      Date.new(year.to_i, month.to_i).beginning_of_month
+    end
   end
 
-  def quarterly_date
-    (quarter_to_date + 2.months).end_of_month
+  def quarterly_date(date_type)
+    if date_type == :end
+      (quarter_to_date + 2.months).end_of_month
+    else
+      (quarter_to_date + 2.months).beginning_of_month
+    end
   end
 
   def quarter_to_date
@@ -51,12 +64,20 @@ class Link < Datafile
     4 + (quarter.to_i - 1) * 3 # Q1: 4, Q2: 7, Q3: 10, Q4: 13
   end
 
-  def yearly_date
-    Date.new(year.to_i).end_of_year
+  def yearly_date(date_type)
+    if date_type == :end
+      Date.new(year.to_i).end_of_year
+    else
+      Date.new(year.to_i).beginning_of_year
+    end
   end
 
-  def financial_yearly_date
-    Date.new(year.to_i + 1).end_of_quarter
+  def financial_yearly_date(date_type)
+    if date_type == :end
+      Date.new(year.to_i + 1).end_of_quarter
+    else
+      Date.new(year.to_i + 1).beginning_of_quarter
+    end
   end
 
   def validate_date_input

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -5,6 +5,7 @@ class Legacy::DatasetImportService
     @legacy_dataset = legacy_dataset
     @orgs_cache = orgs_cache
     @themes_cache = themes_cache
+    @logger = Logger.new(STDOUT)
   end
 
   def run
@@ -86,17 +87,22 @@ class Legacy::DatasetImportService
   end
 
   def create_datafile_date_attributes(resource)
-    if resource["date"].blank?
-      {}
-    else
-      date = get_end_date(resource["date"])
-      end_date = Date.parse(date)
-      {
-        day: end_date.day,
-        month: end_date.month,
-        year: end_date.year
-      }
-    end
+    return {} if resource["date"].blank?
+    date = get_end_date(resource["date"])
+    end_date = parse_date(date)
+
+    {
+      day: end_date&.day,
+      month: end_date&.month,
+      year: end_date&.year
+    }
+  end
+
+  def parse_date(date)
+    Date.parse(date)
+  rescue ArgumentError
+    @logger.error("Invalid date detected: '#{date}'. Returning nil")
+    nil
   end
 
   def datafile_name(resource)

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -50,7 +50,6 @@ describe Legacy::DatasetImportService do
       expect(first_imported_datafile.name).to eql(first_resource["description"])
       expect(first_imported_datafile.created_at).to eql(imported_dataset.created_at)
       expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
-      expect(first_imported_datafile.start_date).to eql(Date.parse(first_resource["date"]).beginning_of_month)
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
     end
 


### PR DESCRIPTION
This PR makes the way we set `start_date` and `end_date` on datafiles consistent across legacy and publish.

Previously start date and end date were being set by the `dataset_import_service`. 
However there was also a `before_save` on the link model to set `end_date`. 

This meant:
 - Imported datafiles were having end date set twice.
- Imported datafiles had both start and end dates
- Published datasets would always have a start_date of nil.

Removal of either one of start or end date on the Link model adds complexity to Find. 