### PR TITLE
Add IRC notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,5 @@ deploy:
     on:
       repo: alphagov/datagovuk_publish
       tags: true
+notifications:
+  irc: "chat.freenode.net#datagovuk"


### PR DESCRIPTION
This is to test how useful it is to send all travis notifications to an IRC channel for devs