### PR TITLE
Max/documentation flag

### DIFF
--- a/app/controllers/datasets/docs_controller.rb
+++ b/app/controllers/datasets/docs_controller.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 class Datasets::DocsController < ApplicationController
   before_action :set_dataset, only: [:index, :new, :create, :edit, :update, :confirm_delete, :destroy]
   before_action :set_doc,     only: [:edit, :update, :confirm_delete, :destroy]
@@ -12,6 +13,7 @@ class Datasets::DocsController < ApplicationController
 
   def create
     @doc = @dataset.docs.build(doc_params)
+    @doc.documentation = true
 
     if @doc.save
       redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)

--- a/app/controllers/datasets/links_controller.rb
+++ b/app/controllers/datasets/links_controller.rb
@@ -13,6 +13,7 @@ class Datasets::LinksController < ApplicationController
 
   def create
     @link = @dataset.links.build(link_params)
+    @link.documentation = false
 
     if @link.save
       redirect_to dataset_links_path(@dataset.uuid, @dataset.name)

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -60,6 +60,7 @@ class Legacy::DatasetImportService
       datafile.month = date_attributes[:month]
       datafile.year = date_attributes[:year]
       datafile.assign_attributes(base_attributes)
+      datafile.documentation = false
       datafile.save!(validate: false)
     end
   end
@@ -72,6 +73,7 @@ class Legacy::DatasetImportService
       base_attributes = create_resource_base_attributes(legacy_document, dataset)
 
       document.assign_attributes(base_attributes)
+      document.documentation = true
       document.save!(validate: false)
     end
   end


### PR DESCRIPTION
Currently when datafiles are sent to ES, it doesn't differentiate between data links and documents. That's because the Type field of Datafile (set to Link or Doc) isn't converted to JSON. 
Best would be to separate out Links and Docs and remove Datafile as their common ancestor. In the meantime with this we're setting the (previously unused) `documentation` flag. Find will be modified accordingly.