### PR TITLE
Change git release tagging convention to vX.X.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
 branches:
   only:
   - master
-  - /publish-beta-v*/
+  - /^v\d+\.\d+\.\d+$/
 services:
 - postgresql
 - elasticsearch


### PR DESCRIPTION
https://trello.com/c/GiixWO8N/31-implement-github-tagging-for-production-deployments