### PR TITLE
Set up Publish and its related services to run inside Docker containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.dockerignore
+.byebug_history
+log/*
+tmp/*
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,3 @@ RUN bundle install
 
 # Copy the contents of the Rails app folder into the container
 COPY . /usr/src/app
-
-# Make port 3000 available to the world outside this container
-EXPOSE 3000
-CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use an official Ruby runtime as a parent image
+FROM ruby:2.4.3-alpine
+
+RUN apk update && \
+    apk add --no-cache build-base postgresql-dev nodejs tzdata && \
+    apk add curl wget bash vim && \
+    apk add ruby ruby-bundler && \
+    rm -rf /var/cache/apk/*
+
+# Set the working directory to /usr/src/app
+WORKDIR /usr/src/app
+
+COPY Gemfile /usr/src/app
+COPY Gemfile.lock /usr/src/app
+RUN bundle install
+
+# Copy the contents of the Rails app folder into the container
+COPY . /usr/src/app
+
+# Make port 3000 available to the world outside this container
+EXPOSE 3000
+CMD ["rails", "server", "-b", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ $ vagrant ssh -c "cd /vagrant && bundle exec sidekiq
 To run the app on your local machine, [download](https://store.docker.com) and install Docker CE, then:
 
 * `$ docker-compose up`
-* `$ docker-compose web run rake db:create db:migrate db:seed`
+* `$ docker-compose run web rake db:create db:migrate db:seed`
 
 This will run one container for each of the following:
 

--- a/README.md
+++ b/README.md
@@ -113,3 +113,35 @@ $ vagrant ssh -c /vagrant/tools/vagrant-dev-setup.sh
 $ vagrant ssh -c "cd /vagrant && rails s"
 $ vagrant ssh -c "cd /vagrant && bundle exec sidekiq
 ```
+
+# Docker
+
+To run the app on your local machine, [download](https://store.docker.com) and install Docker CE, then:
+
+* `$ docker-compose up`
+* `$ docker-compose web run rake db:create db:migrate db:seed`
+
+This will run one container for each of the following:
+
+* Rails
+* Postgres
+* Redis
+* Sidekiq
+* ElasticSearch
+
+|   Service     | Container name  |
+| ------------- | --------------- |
+| Rails         | `web`           |
+| Postgres      | `db`            |
+| Redis         | `redis`         |
+| Sidekiq       | `sidekiq`       |
+| ElasticSearch | `elasticsearch` |
+
+To run a command on a container, `docker-compose [container_name] [command]`.
+
+*e.g.*
+
+To stop all the running containers: `docker-compose down`.
+To stop an individual container: `docker-compose stop [container_name]`.
+
+For more commands, full [docker-compose CLI documentation](https://docs.docker.com/compose/reference/overview).

--- a/README.md
+++ b/README.md
@@ -137,11 +137,12 @@ This will run one container for each of the following:
 | Sidekiq       | `sidekiq`       |
 | ElasticSearch | `elasticsearch` |
 
-To run a command on a container, `docker-compose [container_name] [command]`.
+To run a command on a container: `docker-compose [container_name] [command]`.
 
 *e.g.*
 
 To stop all the running containers: `docker-compose down`.
+
 To stop an individual container: `docker-compose stop [container_name]`.
 
 For more commands, full [docker-compose CLI documentation](https://docs.docker.com/compose/reference/overview).

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,9 @@
 default: &default
   adapter: postgresql
   encoding: unicode
+  host: db
+  username: postgres
+  password:
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,7 +7,7 @@ default: &default
 
 development:
   <<: *default
-  host: <%= ENV['DATABASE_HOST'] || localhost %>
+  host: <%= ENV['DATABASE_HOST'] || 'localhost' %>
   database: publish_data_beta_development
   url: <%= ENV['DATABASE_URL'] %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,13 +1,13 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  host: db
   username: postgres
   password:
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
 
 development:
   <<: *default
+  host: <%= ENV['DATABASE_HOST'] || localhost %>
   database: publish_data_beta_development
   url: <%= ENV['DATABASE_URL'] %>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - RAILS_ENV=development
       - REDIS_IP=redis
       - ES_HOST=elasticsearch
+      - DATABASE_HOST=db
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
       - '3000:3000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   sidekiq:
     build: .
-    command: sidekiq -C config/sidekiq.yml.erb
+    command: bundle exec sidekiq
     volumes:
       - '.:/usr/src/app'
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,18 +2,21 @@ version: '3'
 services:
   web:
     build: .
-    env_file:
-      - '.env'
+    environment:
+      - REDIS_IP=redis
+      - ES_HOST=elasticsearch
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
-      - "3000:3000"
+      - '3000:3000'
     volumes:
       - .:/usr/src/app
     depends_on:
       - db
+      - sidekiq
+      - elasticsearch
 
   db:
-    image: "postgres:9.6-alpine"
+    image: 'postgres:9.6-alpine'
     volumes:
       - 'postgres:/var/lib/postgresql/data'
 
@@ -36,6 +39,15 @@ services:
       - 'db'
       - 'redis'
 
+  elasticsearch:
+    image: 'docker.elastic.co/elasticsearch/elasticsearch:5.2.2'
+    ports:
+      - '9200:9200'
+    volumes:
+      - elasticsearch:/usr/share/elasticsearch/data
+
 volumes:
   redis:
   postgres:
+  elasticsearch:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 services:
   web:
     build: .
-    environment:
-      - RAILS_ENV=development
+    env_file:
+      - '.env'
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
     ports:
       - "3000:3000"
@@ -11,5 +11,31 @@ services:
       - .:/usr/src/app
     depends_on:
       - db
+
   db:
     image: "postgres:9.6-alpine"
+    volumes:
+      - 'postgres:/var/lib/postgresql/data'
+
+  redis:
+    image: 'redis:4.0-alpine'
+    command: redis-server
+    ports:
+      - '6379:6379'
+    volumes:
+      - 'redis:/data'
+
+  sidekiq:
+    build: .
+    command: sidekiq -C config/sidekiq.yml.erb
+    volumes:
+      - '.:/usr/src/app'
+    env_file:
+      - '.env'
+    depends_on:
+      - 'db'
+      - 'redis'
+
+volumes:
+  redis:
+  postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   publish_app:
-    image: 'datagovuk/publish-app:v16012018'
+    image: 'datagovuk/publish-app:latest'
     environment:
       - RAILS_ENV=development
       - REDIS_IP=redis
@@ -18,7 +18,7 @@ services:
       - elasticsearch
 
   find_app:
-    image: 'datagovuk/find-app:v16012018'
+    image: 'datagovuk/find-app:latest'
     environment:
       - RAILS_ENV=development
       - ES_HOST=elasticsearch
@@ -44,7 +44,7 @@ services:
       - 'redis:/data'
 
   sidekiq:
-    image: 'datagovuk/publish-app:v16012018'
+    image: 'datagovuk/publish-app:latest'
     environment:
       - REDIS_IP=redis
       - ES_HOST=elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   publish_app:
-    image: 'datagovukteam/publish-app:v16012018'
+    image: 'datagovuk/publish-app:v16012018'
     environment:
       - RAILS_ENV=development
       - REDIS_IP=redis
@@ -17,7 +17,7 @@ services:
       - elasticsearch
 
   find_app:
-    image: 'datagovukteam/find-app:v16012018'
+    image: 'datagovuk/find-app:v16012018'
     environment:
       - RAILS_ENV=development
       - ES_HOST=elasticsearch
@@ -43,7 +43,7 @@ services:
       - 'redis:/data'
 
   sidekiq:
-    image: 'datagovukteam/publish-app:v16012018'
+    image: 'datagovuk/publish-app:v16012018'
     environment:
       - REDIS_IP=redis
       - ES_HOST=elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  web:
+    build: .
+    environment:
+      - RAILS_ENV=development
+    command: bundle exec rails s -p 3000 -b '0.0.0.0'
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/usr/src/app
+    depends_on:
+      - db
+  db:
+    image: "postgres:9.6-alpine"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   web:
     build: .
     environment:
+      - RAILS_ENV=development
       - REDIS_IP=redis
       - ES_HOST=elasticsearch
     command: bundle exec rails s -p 3000 -b '0.0.0.0'
@@ -30,11 +31,11 @@ services:
 
   sidekiq:
     build: .
+    environment:
+      - REDIS_IP=redis
     command: bundle exec sidekiq
     volumes:
       - '.:/usr/src/app'
-    env_file:
-      - '.env'
     depends_on:
       - 'db'
       - 'redis'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
-  web:
-    build: .
+  publish_app:
+    image: 'datagovukteam/publish-app:v16012018'
     environment:
       - RAILS_ENV=development
       - REDIS_IP=redis
@@ -10,10 +10,23 @@ services:
     ports:
       - '3000:3000'
     volumes:
-      - .:/usr/src/app
+      - .:/usr/src/datagovuk_publish
     depends_on:
       - db
       - sidekiq
+      - elasticsearch
+
+  find_app:
+    image: 'datagovukteam/find-app:v16012018'
+    environment:
+      - RAILS_ENV=development
+      - ES_HOST=elasticsearch
+    command: bundle exec rails s -p 3001 -b '0.0.0.0'
+    ports:
+      - '3001:3001'
+    volumes:
+      - .:/usr/src/datagovuk_find
+    depends_on:
       - elasticsearch
 
   db:
@@ -30,18 +43,21 @@ services:
       - 'redis:/data'
 
   sidekiq:
-    build: .
+    image: 'datagovukteam/publish-app:v16012018'
     environment:
       - REDIS_IP=redis
+      - ES_HOST=elasticsearch
     command: bundle exec sidekiq
     volumes:
-      - '.:/usr/src/app'
+      - .:/usr/src/datagovuk_publish
     depends_on:
       - 'db'
       - 'redis'
 
   elasticsearch:
     image: 'docker.elastic.co/elasticsearch/elasticsearch:5.2.2'
+    environment:
+     - "xpack.security.enabled=false"
     ports:
       - '9200:9200'
     volumes:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require 'webmock/rspec'
 
 include WebMock::API
 WebMock.disable_net_connect!(allow_localhost: true)
+WebMock.disable_net_connect!(allow: "#{ENV['ES_HOST']}:9200")
 
 Sidekiq::Testing.inline!
 


### PR DESCRIPTION
This PR sets up Publish and its related services to run inside Docker containers.

Some of the benefits:

* a new developer joining the team just has to install Docker and run `docker-compose up` and `docker-compose run web rake db:create db:migrate db:seed` to have their development environment ready

* all developers work in an identical environment