### PR TITLE
Set end date on import of datafile

### DIFF
--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -76,7 +76,6 @@ namespace :import do
 
   desc "Import datasets from a data.gov.uk dump"
   task :legacy_datasets, [:filename] => :environment do |_, args|
-    Link.skip_callback(:save, :before, :set_end_date)
 
     # Maps the organisation UUIDs to the organisation IDs
     logger = Logger.new(STDOUT)


### PR DESCRIPTION
This PR relates to https://trello.com/c/VVoQtElX/123-imported-datasets-have-no-end-date

There is some old code which is skipping the setting of `end_date` on `datafile.save`. 
```
pry(main)> Link.count
=> 80710

pry(main)> Link.where.not(start_date: nil).count
=> 22359

pry(main)> Link.where.not(end_date: nil).count
=> 0

```
This PR removes that code.