### PR TITLE
Set datafile creation date on import

### DIFF
--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -81,7 +81,7 @@ class Legacy::DatasetImportService
       uuid: resource["id"],
       format: resource["format"],
       name: datafile_name(resource),
-      created_at: dataset.created_at,
+      created_at: resource["created"],
       updated_at: dataset.last_updated_at
     }
   end

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -48,7 +48,7 @@ describe Legacy::DatasetImportService do
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
       expect(first_imported_datafile.name).to eql(first_resource["description"])
-      expect(first_imported_datafile.created_at).to eql(imported_dataset.created_at)
+      expect(first_imported_datafile.created_at).to eql(Time.parse(first_resource["created"]))
       expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
     end


### PR DESCRIPTION
This PR relates to: https://trello.com/c/fRUSfgum/124-datafiles-imported-from-legacy-have-their-parent-datasets-creation-date-rather-than-their-own-creation-date-xs

It will also help implement this: https://trello.com/c/matLU6mH/48-make-last-updated-consistent-on-dataset-show-page

- We are currently setting a datafile's creation date to that of its parent dataset.This seems unnecessary because resources have their own `created` date, we should store this instead.

```
"resources": [
            {
                "hash": "",
                "description": "download",
                "created": "2015-12-17T12:09:03.088202",
                "url": "http://www.emodnet-seabedhabitats.eu/download",
                "format": "HTML",
                "qa": { },
                "tracking_summary": {},
                "resource_locator_function": "download",
                "archiver": {},
                "resource_locator_protocol": "",
                "position": 0,
                "revision_id": "99100abe-3418-4cf4-9354-845936f06852",
                "id": "3b3040ac-919b-4b4c-b5e2-ff8d0e65ad3e",
                "resource_type": "file",
                "name": "Download from the “EUNIS habitat maps from surveys” package, Broad, Medium and Fine scale data"
            }]
```
 