### PR TITLE
Use lowercase normalizer to tokenize datafile formats

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -1,5 +1,16 @@
 class DatasetsIndexerService
-  INDEX_MAPPING = {
+  INDEX_SETTINGS = {
+    analysis: {
+      normalizer: {
+        lowercase_normalizer: {
+          type: "custom",
+          filter: "lowercase"
+        }
+      }
+    }
+  }
+
+  INDEX_MAPPINGS = {
     dataset: {
       properties: {
         name: {
@@ -40,7 +51,10 @@ class DatasetsIndexerService
         datafiles: {
           type: "nested",
           properties: {
-            format: { type: "keyword" }
+            format: {
+              type: "keyword",
+              normalizer: "lowercase_normalizer"
+            }
           }
         }
       }
@@ -76,7 +90,10 @@ class DatasetsIndexerService
   def create_new_index
     client.indices.create(
       index: new_index_name,
-      body: { mappings: INDEX_MAPPING }
+      body: {
+          settings: INDEX_SETTINGS,
+          mappings: INDEX_MAPPINGS
+      }
     )
   end
 

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe DatasetsIndexerService do
-  it "has the correct index mappings" do
+  it "indexes with the correct index mappings" do
     expected_mappings = {
       dataset: {
         properties: {
@@ -43,13 +43,31 @@ describe DatasetsIndexerService do
           datafiles: {
             type: "nested",
             properties: {
-              format: { type: "keyword" }
+              format: {
+                type: "keyword",
+                normalizer: "lowercase_normalizer"
+              }
             }
           }
         }
       }
     }
 
-    expect(DatasetsIndexerService::INDEX_MAPPING).to eql(expected_mappings)
+    expect(DatasetsIndexerService::INDEX_MAPPINGS).to eql(expected_mappings)
+  end
+
+  it "uses a lowercase normalizer to tokenize the datafile format" do
+    expected_settings = {
+      analysis: {
+        normalizer: {
+          lowercase_normalizer: {
+            type: "custom",
+            filter: "lowercase"
+          }
+        }
+      }
+    }
+
+    expect(DatasetsIndexerService::INDEX_SETTINGS).to eql(expected_settings)
   end
 end


### PR DESCRIPTION
Implements a lowercase normalizer for Elastic Search.

This is to make sure Elastic Search tokenizes file formats regardless of case, i.e. "csv" and "CSV" are both tokenized to "csv".

For https://github.com/alphagov/datagovuk_find/pull/360.

https://trello.com/c/r5koAzWE/128-find-bug-datafile-format-filter-list-shows-both-upcased-and-downcased-file-formats