### PR TITLE
Update types in Link table

### DIFF
--- a/db/migrate/20180119102521_rename_types_in_link.rb
+++ b/db/migrate/20180119102521_rename_types_in_link.rb
@@ -1,0 +1,5 @@
+class RenameTypesInLink < ActiveRecord::Migration[5.1]
+  def change
+    Link.where(type: 'Link').update_all(type: 'Datafile')
+  end
+end


### PR DESCRIPTION
Follow on from work to refactor models in publish. Tables were renamed but did not update the types of existing records