### PR TITLE
Test and fix legacy organisations import

### DIFF
--- a/app/services/legacy/organisation_import_service.rb
+++ b/app/services/legacy/organisation_import_service.rb
@@ -31,17 +31,20 @@ class Legacy::OrganisationImportService
       o.org_type = "other-government-body"
     end
 
-    groups = legacy_organisation["groups"] || []
-
-    if groups.size != 0
-      parent = groups[0]["name"]
-      relationships[o.name] = parent
-    end
+    o.parent = parent_organisation if groups.any?
 
     o.save(validate: false)
   end
 
   private
+
+  def parent_organisation
+    Organisation.find_by(name: groups[0]["name"])
+  end
+
+  def groups
+    legacy_organisation.fetch("groups", [])
+  end
 
   def central_government?
     %w("ministerial-department", "non-ministerial-department",

--- a/app/services/legacy/organisation_import_service.rb
+++ b/app/services/legacy/organisation_import_service.rb
@@ -6,7 +6,15 @@ class Legacy::OrganisationImportService
   end
 
   def run
-    organisation.update_columns({
+    if organisation.persisted?
+      organisation.update_columns(organisation_attributes)
+    else
+      organisation.update_attributes(organisation_attributes)
+    end
+  end
+
+  def organisation_attributes
+    {
       uuid: legacy_organisation["id"],
       name: legacy_organisation["name"],
       title: legacy_organisation["title"],
@@ -23,7 +31,7 @@ class Legacy::OrganisationImportService
       category: legacy_organisation["category"],
       org_type: get_org_type,
       ancestry: get_parent_organisation_id
-    })
+    }
   end
 
   private

--- a/app/services/legacy/organisation_import_service.rb
+++ b/app/services/legacy/organisation_import_service.rb
@@ -1,0 +1,56 @@
+class Legacy::OrganisationImportService
+  attr_reader :legacy_organisation
+
+  def initialize(legacy_organisation)
+    @legacy_organisation = legacy_organisation
+  end
+
+  def run
+    o = Organisation.find_by(name: legacy_organisation["name"]) || Organisation.new
+
+    o.uuid = legacy_organisation["id"]
+    o.name = legacy_organisation["name"]
+    o.title = legacy_organisation["title"]
+    o.description = legacy_organisation["description"]
+    o.abbreviation = legacy_organisation["abbreviation"]
+    o.replace_by = "#{legacy_organisation['replaced_by']}"
+    o.contact_email = legacy_organisation["contact-email"]
+    o.contact_phone = legacy_organisation["contact-phone"]
+    o.contact_name = legacy_organisation["contact-name"]
+    o.foi_email = legacy_organisation["foi-email"]
+    o.foi_phone = legacy_organisation["foi-phone"]
+    o.foi_name = legacy_organisation["foi-name"]
+    o.foi_web = legacy_organisation["foi-web"]
+    o.category = legacy_organisation["category"]
+
+    if central_government?
+      o.org_type = "central-government"
+    elsif local_council?
+      o.org_type = "local-authority"
+    else
+      o.org_type = "other-government-body"
+    end
+
+    groups = legacy_organisation["groups"] || []
+
+    if groups.size != 0
+      parent = groups[0]["name"]
+      relationships[o.name] = parent
+    end
+
+    o.save(validate: false)
+  end
+
+  private
+
+  def central_government?
+    %w("ministerial-department", "non-ministerial-department",
+        "devolved", "executive-ndpb", "advisory-ndpb",
+        "tribunal-ndpb", "executive-agency",
+        "executive-office", "gov-corporation").include? legacy_organisation["category"]
+  end
+
+  def local_council?
+    legacy_organisation["category"] == "local-council"
+  end
+end

--- a/lib/tasks/active.rake
+++ b/lib/tasks/active.rake
@@ -10,6 +10,6 @@ namespace :orgs do
       end
     end
 
-    puts "Done. There are #{Organisation.where(active: false).length} inactive organisations."
+    puts "Done. There are #{Organisation.where(active: false).count} inactive organisations."
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -18,28 +18,14 @@ namespace :import do
   task :legacy_organisations, [:filename] => :environment do |_, args|
     logger = Logger.new(STDOUT)
     organisation_count = 0
-    child_organisation_count = 0
-    relationships = {}
-
-    logger.info 'Processing parent organisations'
 
     json_from_lines(args.filename) do |legacy_org|
       Legacy::OrganisationImportService.new(legacy_org).run
       organisation_count += 1
+      print "Importing #{organisation_count} organisations\r"
     end
 
-    logger.info "Imported #{organisation_count} organisations...\r"
-    logger.info "Processing #{relationships.size} child organisations"
-
-    relationships.each do |child, parent|
-      o = Organisation.find_by(name: child)
-      o.parent = Organisation.find_by(name: parent)
-      o.save!(validate: false)
-      child_organisation_count += 1
-    end
-    logger.info "Assigned #{child_organisation_count} organisations...\r"
-
-    logger.info "Import complete"
+    logger.info "Organisation import complete"
   end
 
   desc "Import datasets from a data.gov.uk dump"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -22,47 +22,15 @@ namespace :import do
     relationships = {}
 
     logger.info 'Processing parent organisations'
-    json_from_lines(args.filename) do |obj|
-      o = Organisation.find_by(name: obj["name"]) || Organisation.new
-      o.name = obj["name"]
-      o.title = obj["title"]
-      o.description = obj["description"]
-      o.abbreviation = obj["abbreviation"]
-      o.replace_by = "#{obj['replaced_by']}"
-      o.contact_email = obj["contact_email"]
-      o.contact_phone = obj["contact_phone"]
-      o.contact_name = obj["contact_name"]
-      o.foi_email = obj["foi_email"]
-      o.foi_phone = obj["foi_phone"]
-      o.foi_name = obj["foi_name"]
-      o.foi_web = obj["foi_web"]
-      o.category = obj["category"]
-      o.uuid = obj["id"]
 
-      if %w("ministerial-department", "non-ministerial-department",
-          "devolved", "executive-ndpb", "advisory-ndpb",
-          "tribunal-ndpb", "executive-agency",
-          "executive-office", "gov-corporation").include? obj["category"]
-        o.org_type = "central-government"
-      elsif obj["category"] == "local-council"
-        o.org_type = "local-authority"
-      else
-        o.org_type = "other-government-body"
-      end
-
-      groups = obj["groups"] || []
-
-      if groups.size != 0
-        parent = groups[0]["name"]
-        relationships[o.name] = parent
-      end
-
-      o.save(validate: false)
+    json_from_lines(args.filename) do |legacy_org|
+      Legacy::OrganisationImportService.new(legacy_org).run
       organisation_count += 1
     end
-    logger.info "Imported #{organisation_count} organisations...\r"
 
+    logger.info "Imported #{organisation_count} organisations...\r"
     logger.info "Processing #{relationships.size} child organisations"
+
     relationships.each do |child, parent|
       o = Organisation.find_by(name: child)
       o.parent = Organisation.find_by(name: parent)

--- a/spec/fixtures/legacy_organisation.json
+++ b/spec/fixtures/legacy_organisation.json
@@ -1,0 +1,19 @@
+{
+  "abbreviation":"ED",
+  "approval_status":"approved",
+  "category":"ministerial-department",
+  "contact-email":"jane.bar@example.com",
+  "contact-name":"Jane Bar",
+  "contact-phone":"3456",
+  "description":"Example description",
+  "foi-email":"jdoe@example.com",
+  "foi-name":"John Doe",
+  "foi-phone":"1234",
+  "foi-web":"http://www.example.com",
+  "id":"12345-6789",
+  "is_organization":true,
+  "name":"2gether-nhs-foundation-trust",
+  "replaced_by":[],
+  "title":"2gether NHS Foundation Trust",
+  "type":"organization"
+}

--- a/spec/services/legacy/organisation_import_service_spec.rb
+++ b/spec/services/legacy/organisation_import_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe Legacy::OrganisationImportService do
+  let(:legacy_organisation) do
+    file_path = Rails.root.join('spec', 'fixtures', 'legacy_organisation.json')
+    org_json = File.read(file_path)
+    JSON.parse(org_json).with_indifferent_access
+  end
+
+  describe "#run" do
+    it "builds an organisation from a legacy organisation" do
+      Legacy::OrganisationImportService.new(legacy_organisation).run
+      imported_organisation = Organisation.find_by(uuid: legacy_organisation["id"])
+
+      expect(imported_organisation.uuid).to eql '12345-6789'
+      expect(imported_organisation.name).to eql '2gether-nhs-foundation-trust'
+      expect(imported_organisation.title).to eql '2gether NHS Foundation Trust'
+      expect(imported_organisation.description).to eql 'Example description'
+      expect(imported_organisation.abbreviation).to eql 'ED'
+      expect(imported_organisation.replace_by).to eql '[]'
+
+      expect(imported_organisation.contact_email).to eql 'jane.bar@example.com'
+      expect(imported_organisation.contact_phone).to eql '3456'
+      expect(imported_organisation.contact_name).to eql 'Jane Bar'
+
+      expect(imported_organisation.foi_email).to eql 'jdoe@example.com'
+      expect(imported_organisation.foi_phone).to eql '1234'
+      expect(imported_organisation.foi_name).to eql 'John Doe'
+      expect(imported_organisation.foi_web).to eql 'http://www.example.com'
+    end
+
+    it "assigns the organisation type to 'central-government' from relevant set of categories" do
+      %w("ministerial-department", "non-ministerial-department",
+          "devolved", "executive-ndpb", "advisory-ndpb",
+          "tribunal-ndpb", "executive-agency",
+          "executive-office", "gov-corporation").each do |category|
+            legacy_organisation["category"] = category
+            Legacy::OrganisationImportService.new(legacy_organisation).run
+            imported_organisation = Organisation.find_by(uuid: legacy_organisation["id"])
+
+            expect(imported_organisation.org_type).to eql 'central-government'
+          end
+    end
+
+    it "assigns the organisation type to 'local-council' from relevant category" do
+      legacy_organisation["category"] = 'local-council'
+      Legacy::OrganisationImportService.new(legacy_organisation).run
+      imported_organisation = Organisation.find_by(uuid: legacy_organisation["id"])
+
+      expect(imported_organisation.org_type).to eql 'local-authority'
+    end
+
+    it "assigns the organisation type to 'other-government-body' from all other categories" do
+      legacy_organisation["category"] = 'foo'
+      Legacy::OrganisationImportService.new(legacy_organisation).run
+      imported_organisation = Organisation.find_by(uuid: legacy_organisation["id"])
+
+      expect(imported_organisation.org_type).to eql 'other-government-body'
+    end
+  end
+end


### PR DESCRIPTION
In Find, we display contact details present on the dataset. If they are not present, we fetch the contact details from its parent organisation. Many datasets had no contact details because their parent org had none.

Actually, no organisation in Beta had any contact details, because the import was using wrong keys to retrieve them.

This PR fixes the import and adds test coverage.

https://trello.com/c/iGmqyQAm/126-make-sure-dataset-contact-details-are-present-on-the-organisation-model