### PR TITLE
Set Link created date 

### DIFF
--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -81,7 +81,7 @@ class Legacy::DatasetImportService
       uuid: resource["id"],
       format: resource["format"],
       name: datafile_name(resource),
-      created_at: resource["created"],
+      created_at: resource["created"] || dataset.created_at,
       updated_at: dataset.last_updated_at
     }
   end

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -53,6 +53,17 @@ describe Legacy::DatasetImportService do
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
     end
 
+    it "sets datafile created_at date to resource created date, if present" do
+      legacy_dataset['resources'].first['created'] = nil
+      dataset_with_resource_without_created_date = legacy_dataset
+      Legacy::DatasetImportService.new(dataset_with_resource_without_created_date, orgs_cache, themes_cache).run
+      imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
+      imported_datafiles = imported_dataset.links
+      first_imported_datafile = imported_datafiles.first
+
+      expect(first_imported_datafile.created_at).to eql(imported_dataset.created_at)
+    end
+
     it "builds a dataset from a non timeseries legacy dataset" do
       Legacy::DatasetImportService.new(non_timeseries_legacy_dataset, orgs_cache, themes_cache).run
       expect(Dataset.last.frequency).to eq('never')


### PR DESCRIPTION
This PR relates to https://github.com/alphagov/datagovuk_publish/pull/495

When we import a dataset, the Link's `created_at` date is set to the resource's `created_date`. However, sometimes this field is nil, for reasons only ckan knows. This PR set's the link's `created_at` date to the parent package's `created date`, if that's the case.