### PR TITLE
Handle dataset import with background job

### DIFF
--- a/app/workers/dataset_import_worker.rb
+++ b/app/workers/dataset_import_worker.rb
@@ -1,0 +1,8 @@
+class DatasetImportWorker
+  include Sidekiq::Worker
+  sidekiq_options :queue => :importer, :retry => false
+
+  def perform(legacy_dataset, orgs_cache, theme_cache)
+    Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, theme_cache).run
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+---
+:concurrency: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
+
+:queues:
+  - default
+  - importer

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -40,7 +40,7 @@ namespace :import do
     json_from_lines(args.filename) do |legacy_dataset|
       counter += 1
       print "Completed #{counter}\r"
-      Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, theme_cache).run
+      DatasetImportWorker.perform_async(legacy_dataset, orgs_cache, theme_cache)
     end
     logger.info 'Import complete'
   end


### PR DESCRIPTION
Dataset imports are painfully slow, so this is an attempt at speeding up the process.

It also has these added benefits:

* we can run multiple imports in parallel (= `RAILS_MAX_THREADS` or `5` by default)
* easy to track progress and errors on a dataset-per-dataset basis
* doesn't take memory away from the Rails application
* in their own queue, so we don't interfere with regular mission-critical jobs, that currently go into the `default` queue