### PR TITLE
Datafiles with no resource_type are datafiles too

### DIFF
--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -179,8 +179,8 @@ class Legacy::DatasetImportService
     get_extra("harvest_object_id").present?
   end
 
-  # Given a lax legacy date string, try and build a proper
-  # date string that we can import
+  private
+
   def get_end_date(date_string)
     # eg "1983"
     if date_string.length == 4
@@ -198,8 +198,6 @@ class Legacy::DatasetImportService
     ""
   end
 
-  # Date helpers
-
   def calculate_dates_for_month(month, year)
     days = Time.days_in_month(month, year)
     "#{days}/#{month}/#{year}"
@@ -209,10 +207,8 @@ class Legacy::DatasetImportService
     "31/12/#{year}"
   end
 
-  private
-
   def legacy_datafiles
-    resources.select{ |resource| resource['resource_type'] == 'file'}
+    resources.select{ |resource| resource['resource_type'] != 'documentation'}
   end
 
   def legacy_documents
@@ -224,7 +220,7 @@ class Legacy::DatasetImportService
   end
 
   def calculate_quarterly_dates(date_object)
-    Date.new(date_object.year, 1+(date_object.month -1 )/4*4)
+    Date.new(date_object.year, 1 + (date_object.month -1 ) / 4 * 4)
   end
 
   def dataset

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -208,11 +208,11 @@ class Legacy::DatasetImportService
   end
 
   def legacy_datafiles
-    resources.select{ |resource| resource['resource_type'] != 'documentation'}
+    resources.reject { |resource| resource['resource_type'] == 'documentation'}
   end
 
   def legacy_documents
-    resources.select{ |resource| resource['resource_type'] == 'documentation'}
+    resources.select { |resource| resource['resource_type'] == 'documentation'}
   end
 
   def resources

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -52,6 +52,14 @@
       "format": "html",
       "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
       "resource_type": "documentation"
+    },
+    {
+      "hash": "",
+      "description": "Resource 3 description",
+      "created": "2017-12-05T09:35:25.928982",
+      "url": "https://example.com/something_maybe",
+      "format": "Some format",
+      "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
     }
   ],
   "timeseries_resources": [

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -44,7 +44,7 @@ describe Legacy::DatasetImportService do
       first_imported_datafile = imported_datafiles.first
       first_resource = legacy_dataset["resources"][0]
 
-      expect(imported_datafiles.count).to eql(2)
+      expect(imported_datafiles.count).to eql(3)
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
       expect(first_imported_datafile.name).to eql(first_resource["description"])
@@ -305,5 +305,4 @@ describe Legacy::DatasetImportService do
     legacy_land_registry_dataset = File.read(file_path)
     JSON.parse(legacy_land_registry_dataset).with_indifferent_access
   end
-
 end


### PR DESCRIPTION
In the dataset importer, we select datafiles based on their `resource_type`. If it's `file`, they're a datafile, if it's `documentation`, they're supporting documentation.

However, it turns out not all datafiles are created equal in legacy. Some don't have a `resource_type` field. As a result, they get ignored.

This makes sure we import all datafiles. We recognize datafiles to be files if they are not documentation. This is not ideal, because it could be that some supporting documents have no `resource_type` either, but at least no one gets left behind, and we can iterate once we know more about this.

https://trello.com/c/xK99B0fA/95-missing-datafiles-on-find