### PR TITLE
Bug-fix: Elasticsearch re-index cleanup

### DIFF
--- a/spec/services/index_deletion_service_spec.rb
+++ b/spec/services/index_deletion_service_spec.rb
@@ -1,45 +1,58 @@
 require 'rails_helper'
 
 describe IndexDeletionService do
-  it 'deletes all indexes except the three most recent' do
-    client_double = double('client')
+  INDEX_CREATED_THIS_MORNING = 'datasets-test_20171122070000'.freeze
+  INDEX_CREATED_YESTERDAY = 'datasets-test_20171121070000'.freeze
+  INDEX_CREATED_LAST_WEEK = 'datasets-test_20171112070000'.freeze
+  INDEX_CREATED_LAST_MONTH = 'datasets-test_20171022070000'.freeze
+
+  before(:each) do
+    @client_double = double('client')
     logger_double = double('logger', info: '')
-
-    index_from_this_morning = 'datasets-test_20171122070000'
-    index_from_yesterday = 'datasets-test_20171121070000'
-    index_from_last_week = 'datasets-test_20171112070000'
-    index_from_last_month = 'datasets-test_20171022070000'
-    legacy_index = 'datasets-development'
-
-    indexes = [
-      index_from_this_morning,
-      index_from_yesterday,
-      index_from_last_week,
-      index_from_last_month
-    ]
-
-    indexes_to_keep = indexes.select { |index| index != index_from_this_morning }
 
     index_deleter_args = {
       index_alias: "datasets-#{ENV['RAILS_ENV']}",
-      client: client_double,
+      client: @client_double,
       logger: logger_double
     }
 
-    allow(client_double).to receive_message_chain('indices.get_aliases.keys') { indexes }
-    allow(client_double).to receive_message_chain('indices.delete') { true }
+    @index_deleter = IndexDeletionService.new(index_deleter_args)
+  end
 
-    index_deleter = IndexDeletionService.new(index_deleter_args)
+  describe 'when there are more than three indices' do
+    it 'deletes the correct number of indices' do
+      indexes = [
+        INDEX_CREATED_THIS_MORNING,
+        INDEX_CREATED_YESTERDAY,
+        INDEX_CREATED_LAST_WEEK,
+        INDEX_CREATED_LAST_MONTH
+      ]
 
-    index_deleter.run
+      allow(@client_double).to receive_message_chain(:indices, :get_aliases, :keys) { indexes }
+      allow(@client_double).to receive_message_chain(:indices, :delete)
 
-    expect(client_double)
-      .to receive(:'indices.delete')
-      .with(indexes_to_keep)
-      .never
+      expect(@client_double.indices)
+        .to receive(:delete)
+        .with(index: INDEX_CREATED_LAST_MONTH)
 
-    expect(client_double)
-      .to_not receive(:'indices.delete')
-      .with([index_from_this_morning, legacy_index])
+      @index_deleter.run
+    end
+  end
+
+  describe 'when there are less than three indices' do
+    it 'deletes the correct number of indices' do
+      indexes = [
+        INDEX_CREATED_THIS_MORNING,
+        INDEX_CREATED_LAST_WEEK,
+      ]
+
+      allow(@client_double).to receive_message_chain('indices.get_aliases.keys') { indexes }
+      allow(@client_double).to receive_message_chain('indices.delete') { true }
+
+      expect(@client_double)
+        .to_not receive(:'indices.delete')
+
+      @index_deleter.run
+    end
   end
 end


### PR DESCRIPTION
Following a re-index, the newly created index would be deleted if the total number of indexes was less than three. Tests were giving false positives :-(
