### PR TITLE
Generate short ids for Datasets and Links

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -124,7 +124,7 @@ class Dataset < ApplicationRecord
   end
 
   def generate_short_id
-    SecureRandom.urlsafe_base64(6, true)
+    SecureRandom.urlsafe_base64(8, true)
   end
 
   def set_name

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -12,6 +12,8 @@ class Dataset < ApplicationRecord
   document_type "dataset"
 
   after_initialize :set_uuid
+  after_initialize :set_short_id
+
   before_save :set_name
   before_destroy :prevent_if_published
 
@@ -24,7 +26,7 @@ class Dataset < ApplicationRecord
   has_one :inspire_dataset
 
   validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
-                        allow_nil: true # To allow creation before setting this value
+    allow_nil: true # To allow creation before setting this value
   validates :title, presence: true, format: { with: TITLE_FORMAT }
   validates :summary, presence: true
   validates :frequency, presence: true, if: :published?
@@ -66,13 +68,13 @@ class Dataset < ApplicationRecord
              :location1, :location2, :location3,
              :licence, :licence_other, :frequency,
              :published_date, :last_updated_at, :created_at,
-             :harvested, :uuid],
-      include: {
-        organisation: {},
-        datafiles: {},
-        docs: {},
-        inspire_dataset: {}
-      }
+             :harvested, :uuid, :short_id],
+             include: {
+               organisation: {},
+               datafiles: {},
+               docs: {},
+               inspire_dataset: {}
+             }
     )
   end
 
@@ -107,6 +109,22 @@ class Dataset < ApplicationRecord
     if self.uuid.blank?
       self.uuid = SecureRandom.uuid
     end
+  end
+
+  def set_short_id
+    if self.short_id.blank?
+      candidate_short_id = generate_short_id 
+
+      while Dataset.where(short_id: candidate_short_id).exists? do
+        candidate_short_id = generate_short_id
+      end
+
+      self.short_id = candidate_short_id
+    end
+  end
+
+  def generate_short_id
+    SecureRandom.urlsafe_base64(6, true)
   end
 
   def set_name

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -30,6 +30,6 @@ class Link < ApplicationRecord
   end
 
   def generate_short_id
-    SecureRandom.urlsafe_base64(6, true)
+    SecureRandom.urlsafe_base64(8, true)
   end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -9,7 +9,7 @@ class Link < ApplicationRecord
   validates_with UrlValidator
 
   before_save :set_uuid
-
+  after_initialize :set_short_id
 
   def set_uuid
     if self.uuid.blank?
@@ -17,4 +17,19 @@ class Link < ApplicationRecord
     end
   end
 
+  def set_short_id
+    if self.short_id.blank?
+      candidate_short_id = generate_short_id 
+
+      while Link.where(short_id: candidate_short_id).exists? do
+        candidate_short_id = generate_short_id
+      end
+
+      self.short_id = candidate_short_id
+    end
+  end
+
+  def generate_short_id
+    SecureRandom.urlsafe_base64(6, true)
+  end
 end

--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -25,6 +25,10 @@ class DatasetsIndexerService
           type: 'string',
           index: 'not_analyzed'
         },
+        short_id: {
+          type: 'string',
+          index: 'not_analyzed',
+        },
         location1: {
           type: 'string',
           fields: {

--- a/db/migrate/20180126120418_add_short_id_to_dataset.rb
+++ b/db/migrate/20180126120418_add_short_id_to_dataset.rb
@@ -1,0 +1,6 @@
+class AddShortIdToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :short_id, :string, unique: true
+    add_index :datasets, :short_id, unique: true
+  end
+end

--- a/db/migrate/20180128210121_add_short_id_to_link.rb
+++ b/db/migrate/20180128210121_add_short_id_to_link.rb
@@ -1,0 +1,6 @@
+class AddShortIdToLink < ActiveRecord::Migration[5.1]
+  def change
+    add_column :links, :short_id, :string, unique: true
+    add_index :links, :short_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,6 +102,8 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.string "foi_email"
     t.string "foi_phone"
     t.string "foi_web"
+    t.string "short_id"
+    t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -152,6 +152,8 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.string "uuid"
     t.datetime "last_modified"
     t.string "type"
+    t.string "short_id"
+    t.index ["short_id"], name: "index_links_on_short_id", unique: true
     t.index ["uuid"], name: "index_links_on_uuid"
   end
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -110,4 +110,22 @@ describe Dataset do
 
     expect(dataset.last_updated_at).to eq last_updated_at
   end
+
+  it "generates a unique short_id upon initialising" do
+    dataset = Dataset.new
+    expect(dataset.short_id).to_not be_nil 
+  end
+
+  it "continues to generate short_ids until it has found a unique one" do
+
+    short_id = '123abc'
+    unique_short_id = 'unique'
+
+    allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
+
+    existing_dataset = FactoryGirl.create(:dataset)
+    new_dataset = Dataset.new
+
+    expect(new_dataset.short_id).to eq(unique_short_id)
+  end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -111,21 +111,22 @@ describe Dataset do
     expect(dataset.last_updated_at).to eq last_updated_at
   end
 
-  it "generates a unique short_id upon initialising" do
-    dataset = Dataset.new
-    expect(dataset.short_id).to_not be_nil 
-  end
+  describe 'after initializing' do
+    it "generates a unique short_id upon initialising" do
+      dataset = Dataset.new
+      expect(dataset.short_id).to_not be_nil 
+    end
 
-  it "continues to generate short_ids until it has found a unique one" do
+    it "continues to generate short_ids until it has found a unique one" do
+      short_id = '123abc'
+      unique_short_id = 'unique'
 
-    short_id = '123abc'
-    unique_short_id = 'unique'
+      allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
 
-    allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
+      FactoryGirl.create(:dataset)
+      new_dataset = Dataset.new
 
-    existing_dataset = FactoryGirl.create(:dataset)
-    new_dataset = Dataset.new
-
-    expect(new_dataset.short_id).to eq(unique_short_id)
+      expect(new_dataset.short_id).to eq(unique_short_id)
+    end
   end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -19,6 +19,24 @@ describe Link, type: :model do
     end
   end
 
+  describe 'after initializing' do
+    it "generates a unique short_id upon initialising" do
+      expect(@link.short_id).to_not be_nil 
+    end
+
+    it "continues to generate short_ids until it has found a unique one" do
+      short_id = '123abc'
+      unique_short_id = 'unique'
+
+      allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
+
+      FactoryGirl.create(:link)
+      new_link = Link.new
+
+      expect(new_link.short_id).to eq(unique_short_id)
+    end
+  end
+
   describe 'before saving' do
     it 'should be assigned a uuid if it does not have one' do
       @link.uuid = nil

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -17,6 +17,10 @@ describe DatasetsIndexerService do
             type: 'string',
             index: 'not_analyzed'
           },
+          short_id: {
+            type: 'string',
+            index: 'not_analyzed'
+          },
           location1: {
             type: 'string',
             fields: {


### PR DESCRIPTION
Corresponding PR for Find Beta - https://github.com/alphagov/datagovuk_find/pull/374

https://trello.com/c/kt5eSCvX/46-shorten-dataset-urls

The data model now stores a short id (6 characters long) which will replace the use of uuid's in urls. Short ids are unique (there are checks to confirm no two short ids are the same)

*New url format*

http://localhost:3000/dataset/oGckXH/[dataset-name]/datafile/pXcFXt/[datafile-name]