### PR TITLE
Correction to short_id generation

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -124,7 +124,7 @@ class Dataset < ApplicationRecord
   end
 
   def generate_short_id
-    SecureRandom.urlsafe_base64(8, true)
+    SecureRandom.urlsafe_base64(6, true)
   end
 
   def set_name

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -30,6 +30,6 @@ class Link < ApplicationRecord
   end
 
   def generate_short_id
-    SecureRandom.urlsafe_base64(8, true)
+    SecureRandom.urlsafe_base64(6, true)
   end
 end


### PR DESCRIPTION
The first parameter in the urlsafe_base64 method specifies the length
in bytes, not the length in characters. Param changed from 8 to 6 to
generate a short_id with character length of 8.