### PR TITLE
Fix sidekiq concurrency

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bin/sidekiq -c 10
+worker: bin/sidekiq

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bundle exec sidekiq -c 10
+worker: bin/sidekiq -c 10


### PR DESCRIPTION
Concurrency is configured in `config/sidekiq.yml`. The default mirrors that of the database connection pool so that enough database connections are available for the number of worker processes.

If we want to override the concurrency value we should run foreman with a RAILS_MAX_THREADS environmental variable set.