### PR TITLE
Delegate link checking to a background job

### DIFF
--- a/app/workers/link_checker_worker.rb
+++ b/app/workers/link_checker_worker.rb
@@ -1,7 +1,9 @@
 class LinkCheckerWorker
   include Sidekiq::Worker
+  sidekiq_options :queue => :link_checker, :retry => 3
 
-  def perform(*args)
-    # Do something
+  def perform(link_id)
+    link = Link.find(link_id)
+    LinkCheckerService.new(link).run
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -5,3 +5,4 @@
   - default
   - importer
   - indexer
+  - link_checker


### PR DESCRIPTION
Delegate link checking to a background job to speed up the process and make debugging easier.