### PR TITLE
Smarter link checker

### DIFF
--- a/app/services/link_checker_service.rb
+++ b/app/services/link_checker_service.rb
@@ -8,10 +8,10 @@ class LinkCheckerService
   def run
     begin
       check_link
-    rescue RestClient::ExceptionWithResponse
+    rescue RestClient::ExceptionWithResponse => error
       link.broken = true
       link.save(validate: false)
-      create_broken_link_task
+      create_broken_link_task(error)
     end
   end
 
@@ -27,7 +27,7 @@ class LinkCheckerService
     link.save(validate: false)
   end
 
-  def create_broken_link_task
+  def create_broken_link_task(error)
     task = Task.find_or_initialize_by(related_object_id: dataset.uuid, category: "broken")
     task.attributes = {
       organisation_id: organisation.id,
@@ -36,7 +36,7 @@ class LinkCheckerService
       category: "broken",
       quantity: broken_link_count,
       related_object_id: dataset.uuid,
-      description: "'#{dataset.title}' contains broken links"
+      description: error.message
     }
     task.save
   end

--- a/app/services/link_checker_service.rb
+++ b/app/services/link_checker_service.rb
@@ -67,7 +67,7 @@ class LinkCheckerService
   end
 
   def working?
-    response.code > 199 && response.code < 299
+    response.net_http_res.is_a?(Net::HTTPSuccess)
   end
 
   def file_format

--- a/app/services/link_checker_service.rb
+++ b/app/services/link_checker_service.rb
@@ -9,7 +9,8 @@ class LinkCheckerService
     begin
       check_link
     rescue RestClient::ExceptionWithResponse
-      link.update(broken: true)
+      link.broken = true
+      link.save(validate: false)
       create_broken_link_task
     end
   end
@@ -17,12 +18,13 @@ class LinkCheckerService
   private
 
   def check_link
-    link.update({
+    link.attributes = {
       broken: !working?,
       format: file_format,
       size: file_size,
       last_check: DateTime.now
-    })
+    }
+    link.save(validate: false)
   end
 
   def create_broken_link_task

--- a/app/services/link_checker_service.rb
+++ b/app/services/link_checker_service.rb
@@ -54,7 +54,7 @@ class LinkCheckerService
   end
 
   def response
-    @response ||= RestClient.head(link.url)
+    @response ||= RestClient::Request.execute(method: :head, url: link.url, timeout: 5)
   end
 
   def last_modified

--- a/spec/services/link_checker_service_spec.rb
+++ b/spec/services/link_checker_service_spec.rb
@@ -29,7 +29,7 @@ describe LinkCheckerService do
           category: "broken",
           quantity: 1,
           related_object_id: link.dataset.uuid,
-          description: %('#{link.dataset.title}' contains broken links)
+          description: "404 Not Found"
           )
     end
 


### PR DESCRIPTION
* skip link validation on save
* defer to `Ruby Net::HTTP` for checking if response is a success
* save the response error message onto the `Task` description for better reporting
* enforce a timeout for requests
* add a rake task to check all links in the DB