### PR TITLE
Upgrade deprecated Elasticsearch string types

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -14,39 +14,39 @@ class DatasetsIndexerService
     dataset: {
       properties: {
         name: {
-          type: 'string',
-          index: 'not_analyzed'
+          type: 'keyword',
+          index: true,
         },
         legacy_name: {
-          type: 'string',
-          index: 'not_analyzed'
+          type: 'keyword',
+          index: true,
         },
         uuid: {
-          type: 'string',
-          index: 'not_analyzed'
+          type: 'keyword',
+          index: true,
         },
         short_id: {
-          type: 'string',
-          index: 'not_analyzed',
+          type: 'keyword',
+          index: true,
         },
         location1: {
-          type: 'string',
+          type: 'text',
           fields: {
             raw: {
-              type: 'string',
-              index: 'not_analyzed'
-            }
-          }
+              type: 'keyword',
+              index: true,
+            },
+          },
         },
         organisation: {
           type: 'nested',
           properties: {
             title: {
-              type: 'string',
+              type: 'text',
               fields: {
                 raw: {
-                  type: 'string',
-                  index: 'not_analyzed'
+                  type: 'keyword',
+                  index: true,
                 }
               }
             }
@@ -56,11 +56,11 @@ class DatasetsIndexerService
           type: 'nested',
           properties: {
             title: {
-              type: 'string',
+              type: 'text',
               fields: {
                 raw: {
-                  type: 'string',
-                  index: 'not_analyzed'
+                  type: 'keyword',
+                  index: true,
                 }
               }
             }

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -6,27 +6,27 @@ describe DatasetsIndexerService do
       dataset: {
         properties: {
           name: {
-            type: 'string',
-            index: 'not_analyzed'
+            type: 'keyword',
+            index: true,
           },
           legacy_name: {
-            type: 'string',
-            index: 'not_analyzed'
+            type: 'keyword',
+            index: true,
           },
           uuid: {
-            type: 'string',
-            index: 'not_analyzed'
+            type: 'keyword',
+            index: true,
           },
           short_id: {
-            type: 'string',
-            index: 'not_analyzed'
+            type: 'keyword',
+            index: true,
           },
           location1: {
-            type: 'string',
+            type: 'text',
             fields: {
               raw: {
-                type: 'string',
-                index: 'not_analyzed'
+                type: 'keyword',
+                index: true,
               }
             }
           },
@@ -34,11 +34,11 @@ describe DatasetsIndexerService do
             type: 'nested',
             properties: {
               title: {
-                type: 'string',
+                type: 'text',
                 fields: {
                   raw: {
-                    type: 'string',
-                    index: 'not_analyzed'
+                    type: 'keyword',
+                    index: true,
                   }
                 }
               }
@@ -48,11 +48,11 @@ describe DatasetsIndexerService do
             type: 'nested',
             properties: {
               title: {
-                type: 'string',
+                type: 'text',
                 fields: {
                   raw: {
-                    type: 'string',
-                    index: 'not_analyzed'
+                    type: 'keyword',
+                    index: true,
                   }
                 }
               }


### PR DESCRIPTION
String types are no longer supported in Elasticsearch 6.0. The string field has split into two new types: text, which should be used for full-text search, and keyword, which should be used for keyword search.

The previous mappings are currently working because Elasticsearch 5.0 has backward compatibility that is removed with Elasticsearch 6.0.

See https://www.elastic.co/blog/strings-are-dead-long-live-strings