### PR TITLE
FIX - import missing topics from legacy

### DIFF
--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -52,20 +52,47 @@ class Legacy::DatasetImportService
     }
   end
 
+  # Deprecated
   def build_theme_id
-    themes_cache.fetch(legacy_dataset["theme-primary"], nil)
+    return unless legacy_dataset["theme-primary"]
+
+    topic = convert_topic(legacy_dataset["theme-primary"])
+
+    themes_cache.fetch(topic, nil)
   end
 
+  # Deprecated
   def build_secondary_theme_id
-    themes_cache.fetch(legacy_dataset["theme-secondary"], nil)
+    return unless legacy_dataset["theme-secondary"]
+
+    topic = convert_topic(legacy_dataset["theme-secondary"].first)
+
+    themes_cache.fetch(topic, nil)
   end
 
   def build_topic_id
-    topics_cache.fetch(legacy_dataset["theme-primary"], nil)
+    return unless legacy_dataset["theme-primary"]
+
+    topic = convert_topic(legacy_dataset["theme-primary"])
+
+    topics_cache.fetch(topic, nil)
   end
 
   def build_secondary_topic_id
-    topics_cache.fetch(legacy_dataset["theme-secondary"], nil)
+    return unless legacy_dataset["theme-secondary"]
+
+    topic = convert_topic(legacy_dataset["theme-secondary"].first)
+
+    topics_cache.fetch(topic, nil)
+  end
+
+  def convert_topic(legacy_topic)
+    return if legacy_topic.nil?
+
+    legacy_topic
+      .gsub('&', 'and')
+      .tr(' ', '-')
+      .downcase
   end
 
   def create_datafiles

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,8 +33,7 @@ end
 
 puts 'Seeded topics'
 
-# Theme model is depracated - TR
-
+# Theme model is deprecated
 if Theme.count == 0
   Theme.create(
     [

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -33,8 +33,8 @@ namespace :import do
     # Maps the organisation UUIDs to the organisation IDs
     logger = Logger.new(STDOUT)
     orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
-    topic_cache = Topic.all.pluck(:title, :id).to_h
-    theme_cache = Theme.all.pluck(:title, :id).to_h
+    topic_cache = Topic.all.pluck(:name, :id).to_h
+    theme_cache = Theme.all.pluck(:name, :id).to_h
     counter = 0
 
     logger.info 'Importing legacy datasets'

--- a/lib/tasks/sync.rake
+++ b/lib/tasks/sync.rake
@@ -2,8 +2,8 @@ namespace :sync do
   desc 'Sync modified or new datasets from legacy to beta'
   task beta: :environment do |_, args|
     orgs_cache =  Organisation.all.pluck(:uuid, :id).to_h
-    theme_cache = Theme.all.pluck(:title, :id).to_h
-    topic_cache = Topic.all.pluck(:title, :id).to_h
+    theme_cache = Theme.all.pluck(:name, :id).to_h
+    topic_cache = Topic.all.pluck(:name, :id).to_h
 
     args = {
       orgs_cache: orgs_cache,

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -32,7 +32,7 @@
   "update_frequency": "monthly",
   "revision_id": "197dfecf-32e7-4666-b08a-2e35a9536b16",
   "date_released": "15/9/2011",
-  "theme-primary": "Transport",
+  "theme-primary": "Business & Economy",
   "resources": [
     {
       "hash": "",

--- a/spec/services/legacy/beta_sync_service_spec.rb
+++ b/spec/services/legacy/beta_sync_service_spec.rb
@@ -6,8 +6,8 @@ describe Legacy::BetaSyncService do
     @new_datasets_path = 'api/3/action/package_search?q=metadata_created:[NOW-1DAY%20TO%20NOW]&rows=5000'
 
     @orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
-    @theme_cache = Theme.all.pluck(:title, :id).to_h
-    @topic_cache = Topic.all.pluck(:title, :id).to_h
+    @theme_cache = Theme.all.pluck(:name, :id).to_h
+    @topic_cache = Topic.all.pluck(:name, :id).to_h
     @legacy_server = double(:legacy_server)
     @logger = double(:logger, info: true)
 

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -8,8 +8,8 @@ describe Legacy::DatasetImportService do
   let(:non_timeseries_legacy_dataset) { create_dataset_from('non_timeseries_dataset.json') }
 
   let(:orgs_cache) { { legacy_dataset["owner_org"] => 123 } }
-  let(:topics_cache) { { 'Transport' => 12 } }
-  let(:themes_cache) { { 'Transport' => 12 } }
+  let(:topics_cache) { { 'business-and-economy' => 1 } }
+  let(:themes_cache) { { 'business-and-economy' => 1 } }
 
   describe "#run" do
     it "builds a dataset from a legacy dataset" do
@@ -34,8 +34,8 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.foi_email).to eql(legacy_dataset["foi-email"])
       expect(imported_dataset.foi_phone).to eql(legacy_dataset["foi-phone"])
       expect(imported_dataset.foi_web).to eql(legacy_dataset["foi-web"])
-      expect(imported_dataset.theme_id).to eql(12)
-      expect(imported_dataset.topic_id).to eql(12)
+      expect(imported_dataset.theme_id).to eql(1)
+      expect(imported_dataset.topic_id).to eql(1)
     end
 
     it "creates the datafiles for the imported dataset" do
@@ -147,6 +147,29 @@ describe Legacy::DatasetImportService do
 
       type = described_class.new(legacy_dataset, orgs_cache, themes_cache, topics_cache).build_type
       expect(type).to eql("inspire")
+    end
+  end
+
+  describe "#build_topic_id" do
+    it "returns the correct topic_id if license has a valid topic" do
+      legacy_dataset["theme-primary"] = "Business & Economy"
+      topic_id = described_class.new(legacy_dataset, orgs_cache, themes_cache,  topics_cache).build_topic_id
+      
+      expect(topic_id).to eql(1)
+    end
+
+    it "returns nil if the licence has a missing topic" do
+      legacy_dataset["theme-primary"] = ""
+      topic_id = described_class.new(legacy_dataset, orgs_cache, themes_cache,  topics_cache).build_topic_id
+      
+      expect(topic_id).to eql(nil)
+    end
+
+    it "returns nil if the licence has an invalid topic" do
+      legacy_dataset["theme-primary"] = "Some invalid topic"
+      topic_id = described_class.new(legacy_dataset, orgs_cache, themes_cache,  topics_cache).build_topic_id
+      
+      expect(topic_id).to eql(nil)
     end
   end
 


### PR DESCRIPTION
Oh legacy! You and your ways.

Certain topics were not being imported because we were not matching against '&'.

Added some tests for building the topic_id (and theme_id)

Please not that Themes are deprecated in favour of Topics. Once this gets a thumbs up on prod there will be another PR raised to clean up Themes

**Trello card**
https://trello.com/c/Ot65Qefh/80-implement-topics-themes-l