### PR TITLE
Run import and reindex tasks synchronously

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -124,8 +124,11 @@ class DatasetsIndexerService
   end
 
   def bulk_index(datasets)
-    prepared_datasets = prepare_records(datasets)
-    DatasetIndexerWorker.perform_async(prepared_datasets, new_index_name)
+    Dataset.__elasticsearch__.client.bulk(
+      index: index_name,
+      type: ::Dataset.__elasticsearch__.document_type,
+      body: prepare_records(datasets)
+    )
   end
 
   def prepare_records(datasets)

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -41,7 +41,7 @@ namespace :import do
     json_from_lines(args.filename) do |legacy_dataset|
       counter += 1
       print "Completed #{counter}\r"
-      DatasetImportWorker.perform_async(legacy_dataset, orgs_cache, theme_cache, topic_cache)
+      Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, theme_cache, topic_cache).run
     end
     logger.info 'Import complete'
   end


### PR DESCRIPTION
Run import and reindex tasks synchronously until we can fix Redis memory issues.