### PR TITLE
Fix undefined local variable error in datasets indexer

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -125,7 +125,7 @@ class DatasetsIndexerService
 
   def bulk_index(datasets)
     Dataset.__elasticsearch__.client.bulk(
-      index: index_name,
+      index: new_index_name,
       type: ::Dataset.__elasticsearch__.document_type,
       body: prepare_records(datasets)
     )


### PR DESCRIPTION
Fix undefined local variable error introduced in https://github.com/alphagov/datagovuk_publish/pull/522.