### PR TITLE
Update elasticsearch config in initialiser

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -27,7 +27,9 @@ end
 def es_config_from_vcap
   begin
     vcap = JSON.parse(ELASTIC_CONFIG['vcap_services'])
-    es_server = vcap['elasticsearch'][0]['credentials']['uri'].chomp('/')
+    es_servers = vcap['elasticsearch'][0]['credentials']['uris'].map do |uri|
+      uri.chomp('/')
+    end
     es_cert = Base64.decode64(vcap['elasticsearch'][0]['credentials']['ca_certificate_base64'])
   rescue => e
     Rails.logger.fatal "Failed to extract ES creds from VCAP_SERVICES. Exiting"
@@ -38,7 +40,7 @@ def es_config_from_vcap
   es_cert_file = create_es_cert_file(es_cert)
 
   {
-    host: es_server,
+    host: es_servers,
     transport_options: {
       request: {
         timeout: ELASTIC_CONFIG['elastic_timeout']


### PR DESCRIPTION
PAAS has changed the elasticsearch config in VCAP_SERVICES

```
As someone testing our private beta Elasticsearch service we're letting you know that we're changing the way you connect to it from your PaaS applications. We will keep things backwards compatible until no sooner than 19th February 2018.

Elasticsearch allows clients to connect to multiple Elasticsearch hosts. This helps with availability and the balancing of load. Up until now we have only exposed one host. We are now exposing multiple hosts.

Within the VCAP_SERVICES JSON object we now provide a uris key at the same level as the uri key (which is what you currently use to connect). This new key contains an array of Elasticsearch hosts to connect to. You must modify your application to use these values. You may have to restage your app for these to be visible.

From now on all tenants must use the values under the uris key in order to connect to Elasticsearch. The uri key will be removed no sooner than 19th February 2018.

If you have any questions please contact support: https://www.cloud.service.gov.uk/support
```