### PR TITLE
Upgrade Cloud Foundry buildpacks

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   env:
     RAILS_ENV: production
     RACK_ENV: production

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-worker
   memory: 256M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   command: bundle exec sidekiq
   env:
     RAILS_ENV: production

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-staging
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   env:
     RAILS_ENV: staging
     RACK_ENV: staging

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-staging-worker
   memory: 512M
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.6.47
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.13
   command: bundle exec sidekiq
   env:
     RAILS_ENV: staging


### PR DESCRIPTION
> **date: 20 February 2018 at 14:11**
> **subject: [paas-announce] Upcoming buildpack upgrades**
>
> Hi,
>
> We will be upgrading Cloud Foundry on or after 28th February 2018. We’re letting you know about the planned buildpack updates so you can make any changes to your application before the upgrade takes place. Please ensure that your version-pinning is compatible with versions cited in the planned releases. 
>
> ### ruby-buildpack
>
> New version: 1.7.8
>
> Release notes since the last buildpack change:
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.11
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.10
> https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.7.9
>
> If you have any problems using the new versions in the buildpacks or working to these timelines, please contact us via our help desk.
>
> The GOV.UK PaaS team