### PR TITLE
Remove short id logic

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -12,7 +12,6 @@ class Dataset < ApplicationRecord
   document_type "dataset"
 
   after_initialize :set_uuid
-  after_initialize :set_short_id
 
   before_save :set_name
   before_destroy :prevent_if_published
@@ -75,7 +74,7 @@ class Dataset < ApplicationRecord
              :location1, :location2, :location3,
              :licence, :licence_other, :frequency,
              :published_date, :last_updated_at, :created_at,
-             :harvested, :uuid, :short_id],
+             :harvested, :uuid],
              include: {
                organisation: {},
                topic: {},
@@ -117,22 +116,6 @@ class Dataset < ApplicationRecord
     if self.uuid.blank?
       self.uuid = SecureRandom.uuid
     end
-  end
-
-  def set_short_id
-    if self.short_id.blank?
-      candidate_short_id = generate_short_id
-
-      while Dataset.where(short_id: candidate_short_id).exists? do
-        candidate_short_id = generate_short_id
-      end
-
-      self.short_id = candidate_short_id
-    end
-  end
-
-  def generate_short_id
-    SecureRandom.urlsafe_base64(6, true)
   end
 
   def set_name

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -9,29 +9,12 @@ class Link < ApplicationRecord
   validates_with UrlValidator
 
   before_save :set_uuid
-  after_initialize :set_short_id
-  
+
   scope :broken, ->{ where(broken: true) }
 
   def set_uuid
     if self.uuid.blank?
       self.uuid = SecureRandom.uuid
     end
-  end
-
-  def set_short_id
-    if self.short_id.blank?
-      candidate_short_id = generate_short_id 
-
-      while Link.where(short_id: candidate_short_id).exists? do
-        candidate_short_id = generate_short_id
-      end
-
-      self.short_id = candidate_short_id
-    end
-  end
-
-  def generate_short_id
-    SecureRandom.urlsafe_base64(6, true)
   end
 end

--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -25,10 +25,6 @@ class DatasetsIndexerService
           type: 'keyword',
           index: true,
         },
-        short_id: {
-          type: 'keyword',
-          index: true,
-        },
         location1: {
           type: 'text',
           fields: {

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -110,23 +110,4 @@ describe Dataset do
 
     expect(dataset.last_updated_at).to eq last_updated_at
   end
-
-  describe 'after initializing' do
-    it "generates a unique short_id upon initialising" do
-      dataset = Dataset.new
-      expect(dataset.short_id).to_not be_nil 
-    end
-
-    it "continues to generate short_ids until it has found a unique one" do
-      short_id = '123abc'
-      unique_short_id = 'unique'
-
-      allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
-
-      FactoryGirl.create(:dataset)
-      new_dataset = Dataset.new
-
-      expect(new_dataset.short_id).to eq(unique_short_id)
-    end
-  end
 end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -19,24 +19,6 @@ describe Link, type: :model do
     end
   end
 
-  describe 'after initializing' do
-    it "generates a unique short_id upon initialising" do
-      expect(@link.short_id).to_not be_nil 
-    end
-
-    it "continues to generate short_ids until it has found a unique one" do
-      short_id = '123abc'
-      unique_short_id = 'unique'
-
-      allow(SecureRandom).to receive(:urlsafe_base64).and_return(short_id, short_id, unique_short_id)
-
-      FactoryGirl.create(:link)
-      new_link = Link.new
-
-      expect(new_link.short_id).to eq(unique_short_id)
-    end
-  end
-
   describe 'before saving' do
     it 'should be assigned a uuid if it does not have one' do
       @link.uuid = nil

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -17,10 +17,6 @@ describe DatasetsIndexerService do
             type: 'keyword',
             index: true,
           },
-          short_id: {
-            type: 'keyword',
-            index: true,
-          },
           location1: {
             type: 'text',
             fields: {


### PR DESCRIPTION
The current strategy for generating short ids is nondeterministic. We want the same short id to be generated for a given dataset across multiple imports and environments.

This removes the behavior until we can revist it in due course.

A second PR will be raised to migrate the schema.

Closes #532 
See https://trello.com/c/VSLtBp7U and https://trello.com/c/YJEH4PC2