### PR TITLE
Add English field mappings to datasets index

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -17,6 +17,45 @@ class DatasetsIndexerService
           type: 'keyword',
           index: true,
         },
+        title: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
+        summary: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
+        description: {
+          type: 'text',
+          fields: {
+            keyword: {
+              type: 'keyword',
+              index: true,
+            },
+            english: {
+              type: 'text',
+              analyzer: 'english',
+            },
+          },
+        },
         legacy_name: {
           type: 'keyword',
           index: true,
@@ -43,8 +82,25 @@ class DatasetsIndexerService
                 raw: {
                   type: 'keyword',
                   index: true,
-                }
-              }
+                },
+                english: {
+                  type: 'text',
+                  analyzer: 'english',
+                },
+              },
+            },
+            description: {
+              type: 'text',
+              fields: {
+                raw: {
+                  type: 'keyword',
+                  index: true,
+                },
+                english: {
+                  type: 'text',
+                  analyzer: 'english',
+                },
+              },
             }
           }
         },

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -17,6 +17,45 @@ describe DatasetsIndexerService do
             type: 'keyword',
             index: true,
           },
+          title: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                index: true,
+              },
+              english: {
+                type: 'text',
+                analyzer: 'english',
+              },
+            },
+          },
+          summary: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                index: true,
+              },
+              english: {
+                type: 'text',
+                analyzer: 'english',
+              },
+            },
+          },
+          description: {
+            type: 'text',
+            fields: {
+              keyword: {
+                type: 'keyword',
+                index: true,
+              },
+              english: {
+                type: 'text',
+                analyzer: 'english',
+              },
+            },
+          },
           location1: {
             type: 'text',
             fields: {
@@ -35,8 +74,25 @@ describe DatasetsIndexerService do
                   raw: {
                     type: 'keyword',
                     index: true,
-                  }
-                }
+                  },
+                  english: {
+                    type: 'text',
+                    analyzer: 'english',
+                  },
+                },
+              },
+              description: {
+                type: 'text',
+                fields: {
+                  raw: {
+                    type: 'keyword',
+                    index: true,
+                  },
+                  english: {
+                    type: 'text',
+                    analyzer: 'english',
+                  },
+                },
               }
             }
           },


### PR DESCRIPTION
This adds English mappings of certain fields. This will give us additional capability to use multi-fields is to analyze the same field in different ways for better relevance.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/multifields.html#_multi_fields_with_multiple_analyzers

Trello https://trello.com/c/C6ZTU3gt & https://trello.com/c/EwF9fPiJ