### PR TITLE
Remove datasets before importing

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,9 +21,9 @@ class Dataset < ApplicationRecord
   belongs_to :topic, optional: true
   belongs_to :secondary_topic, optional: true
 
-  has_many :datafiles, dependent: :destroy
-  has_many :docs, dependent: :destroy
-  has_one :inspire_dataset, dependent: :destroy
+  has_many :datafiles
+  has_many :docs
+  has_one :inspire_dataset
 
   validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
     allow_nil: true # To allow creation before setting this value

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,9 +21,9 @@ class Dataset < ApplicationRecord
   belongs_to :topic, optional: true
   belongs_to :secondary_topic, optional: true
 
-  has_many :datafiles
-  has_many :docs
-  has_one :inspire_dataset
+  has_many :datafiles, dependent: :destroy
+  has_many :docs, dependent: :destroy
+  has_one :inspire_dataset, dependent: :destroy
 
   validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
     allow_nil: true # To allow creation before setting this value

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -17,6 +17,7 @@ namespace :import do
   desc "Import organisations from legacy"
   task :legacy_organisations, [:filename] => :environment do |_, args|
     logger = Logger.new(STDOUT)
+    Organisation.delete_all
     organisation_count = 0
 
     json_from_lines(args.filename) do |legacy_org|
@@ -34,6 +35,7 @@ namespace :import do
     logger = Logger.new(STDOUT)
     orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
     topic_cache = Topic.all.pluck(:name, :id).to_h
+    Dataset.delete_all
     counter = 0
 
     logger.info 'Importing legacy datasets'

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -35,6 +35,8 @@ namespace :import do
     logger = Logger.new(STDOUT)
     orgs_cache = Organisation.all.pluck(:uuid, :id).to_h
     topic_cache = Topic.all.pluck(:name, :id).to_h
+    InspireDataset.delete_all
+    Link.delete_all
     Dataset.delete_all
     counter = 0
 


### PR DESCRIPTION
To make sure the state of the database is consistent with the state of the Find index, we delete all datasets and its dependents. That way, we avoid keeping datasets in the DB that have been removed from legacy since the last import.