### PR TITLE
Add direnv configuration

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+PATH_add bin


### PR DESCRIPTION
This adds the bin folder to your path so that running 'rake', 'rspec' etc will use the correct binstubs. This only applies if you have direnv installed and you give permission to allow it to use this configuration.

See https://direnv.net