### PR TITLE
Fix iconv deprecation warning

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,7 +201,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    iconv (1.0.4)
+    iconv (1.0.5)
     inherited_resources (1.7.2)
       actionpack (>= 3.2, < 5.2.x)
       has_scope (~> 0.6)


### PR DESCRIPTION
Fixes the following warning:

```
/usr/local/var/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/iconv-1.0.4/lib/iconv/version.rb:1:
warning: constant ::Data is deprecated
```