### PR TITLE
update Loofah gem from 2.2.0 -> 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
       activesupport (>= 4.0)
       logstash-event (~> 1.2.0)
       request_store
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lrucache (0.1.4)


### PR DESCRIPTION
2.2.0 has a security vulnerability. Bumping to patch

`bundle update loofah --patch`