### PR TITLE
Updates the RAM available to the publisher worker

### DIFF
--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: publish-data-beta-worker
-  memory: 256M
+  memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   command: bundle exec sidekiq
   env:


### PR DESCRIPTION
The publish worker has more RAM on staging than on production, so this
PR increases the amount available for production.  This should hopefully
stop errors like

```
2018-04-04T12:48:12.98+0100 [API/0] OUT App instance exited with guid 2ba4e9ae-4553-4d61-9290-e9bd4e499089 
payload: {"instance"=>"68cc3fa5-fd58-4a56-7202-77e9", 
"index"=>0, 
"reason"=>"CRASHED", 
"exit_description"=>"APP/PROC/WEB: Exited with status 137 (out of memory)", 
"crash_count"=>1, 
"crash_timestamp"=>1522842492985954416, 
"version"=>"25a44111-b9ac-47f9-9767-27a3c1cbbad2"}
```