### PR TITLE
Update index_alias to use Rails.env

### DIFF
--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -5,7 +5,7 @@ namespace :search do
     logger = Rails.logger
     client = Dataset.__elasticsearch__.client
     date = Time.now.strftime('%Y%m%d%H%M%S')
-    index_alias = "datasets-#{ENV['RAILS_ENV']}"
+    index_alias = "datasets-#{Rails.env}"
     legacy_index = index_alias
     new_index_name = "#{Dataset.index_name}_#{date}"
 


### PR DESCRIPTION
The previous implementation meant that the index name wouldn't always have the
correct environment appended to it.