### PR TITLE
Make database usable after syncing

### DIFF
--- a/scripts/replication.sh
+++ b/scripts/replication.sh
@@ -8,3 +8,6 @@ cf login -a api.cloud.service.gov.uk
 cf install-plugin conduit
 cf conduit publish-beta-staging-pg -- pg_dump -Fc --no-acl --no-owner --file=tmp/backups/pg.dump
 pg_restore --verbose --clean --no-acl --no-owner -d publish_data_beta_development tmp/backups/pg.dump
+rails db:environment:set RAILS_ENV=development
+psql publish_data_beta_development -c "drop function reassign_owned() cascade;"
+rails db:migrate


### PR DESCRIPTION
After downloading the staging database and installing it, we need to 
tell the database that it is a development database (and not production)
as well as deleting an unused function to ensure we can run migrations.

The downside of this is that it's possible that when creating future
migrations, the schema.rb will attempt to include extensions that are
enabled on staging but may/may-not be installed locally.