### PR TITLE
Add the INSPIRE access constraints field to DB

### DIFF
--- a/db/migrate/2018041310444200_add_inspire_access_constraint_field.rb
+++ b/db/migrate/2018041310444200_add_inspire_access_constraint_field.rb
@@ -1,0 +1,5 @@
+class AddInspireAccessConstraintField < ActiveRecord::Migration[5.1]
+  def change
+    add_column :inspire_datasets, :access_constraints, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2017071231151258) do
+ActiveRecord::Schema.define(version: 2018041310444200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -131,6 +131,7 @@ ActiveRecord::Schema.define(version: 2017071231151258) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid"
+    t.text "access_constraints"
     t.index ["dataset_id"], name: "index_inspire_datasets_on_dataset_id"
     t.index ["uuid"], name: "index_inspire_datasets_on_uuid"
   end


### PR DESCRIPTION
The access constraints from the INSPIRE metadata was missing, and so
this PR adds a migration to put it back as a text block.

Most constraints fall into one of three categories:

* Plain text
* A URL
* Paragraphs and paragraphs of text

Changes to the import/model will come in a separate PR with a rake task
for migrating just that data that is missing.