### PR TITLE
Fix licence handling 

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -73,6 +73,7 @@ class Dataset < ApplicationRecord
              :contact_name, :contact_email, :contact_phone,
              :location1, :location2, :location3,
              :licence, :licence_other, :frequency,
+             :licence_code, :licence_title, :licence_url, :licence_custom,
              :published_date, :last_updated_at, :created_at,
              :harvested, :uuid],
              include: {

--- a/app/models/licence.rb
+++ b/app/models/licence.rb
@@ -1,0 +1,25 @@
+require 'ostruct'
+
+class Licence
+  LicenceInfo = Struct.new(:title, :url)
+
+  LICENCES = {
+    "uk-ogl" => LicenceInfo.new("Open Government Licence", "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"),
+    "cc-nc" => LicenceInfo.new("Creative Commons Non-Commercial (Any)", "http://creativecommons.org/licenses/by-nc/2.0/"),
+    "cc-zero" => LicenceInfo.new("Creative Commons CCZero", "http://www.opendefinition.org/licenses/cc-zero"),
+    "cc-by-sa" => LicenceInfo.new("Creative Commons Attribution Share-Alike", "http://www.opendefinition.org/licenses/cc-by-sa"),
+    "cc-by" => LicenceInfo.new("Creative Commons Attribution", "http://www.opendefinition.org/licenses/cc-by"),
+    "odc-odbl" => LicenceInfo.new("Open Data Commons Open Database License (ODbL)", "http://www.opendefinition.org/licenses/odc-odbl"),
+    "notspecified" => LicenceInfo.new("License Not Specified", nil),
+    "other-pd" => LicenceInfo.new("Other (Public Domain)", nil),
+    "other-open" => LicenceInfo.new("Other (Open)", nil),
+    "other-closed" => LicenceInfo.new("Other (Not Open)", nil),
+    "other-nc" => LicenceInfo.new("Other (Non-Commercial)", nil),
+    "odc-pddl" => LicenceInfo.new("Open Data Commons Public Domain Dedication and License (PDDL)", "http://www.opendefinition.org/licenses/odc-pddl"),
+    "odc-by" => LicenceInfo.new("Open Data Commons Attribution License", "http://www.opendefinition.org/licenses/odc-by"),
+  }
+
+  def self.lookup(licence_id)
+    LICENCES.fetch(licence_id, LicenceInfo.new)
+  end
+end

--- a/app/models/licence.rb
+++ b/app/models/licence.rb
@@ -1,25 +1,23 @@
-require 'ostruct'
-
 class Licence
   LicenceInfo = Struct.new(:title, :url)
 
   LICENCES = {
-    "uk-ogl" => LicenceInfo.new("Open Government Licence", "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"),
+    "cc-by" => LicenceInfo.new("Creative Commons Attribution", "http://www.opendefinition.org/licenses/cc-by"),
+    "cc-by-sa" => LicenceInfo.new("Creative Commons Attribution Share-Alike", "http://www.opendefinition.org/licenses/cc-by-sa"),
     "cc-nc" => LicenceInfo.new("Creative Commons Non-Commercial (Any)", "http://creativecommons.org/licenses/by-nc/2.0/"),
     "cc-zero" => LicenceInfo.new("Creative Commons CCZero", "http://www.opendefinition.org/licenses/cc-zero"),
-    "cc-by-sa" => LicenceInfo.new("Creative Commons Attribution Share-Alike", "http://www.opendefinition.org/licenses/cc-by-sa"),
-    "cc-by" => LicenceInfo.new("Creative Commons Attribution", "http://www.opendefinition.org/licenses/cc-by"),
-    "odc-odbl" => LicenceInfo.new("Open Data Commons Open Database License (ODbL)", "http://www.opendefinition.org/licenses/odc-odbl"),
-    "notspecified" => LicenceInfo.new("License Not Specified", nil),
-    "other-pd" => LicenceInfo.new("Other (Public Domain)", nil),
-    "other-open" => LicenceInfo.new("Other (Open)", nil),
-    "other-closed" => LicenceInfo.new("Other (Not Open)", nil),
-    "other-nc" => LicenceInfo.new("Other (Non-Commercial)", nil),
-    "odc-pddl" => LicenceInfo.new("Open Data Commons Public Domain Dedication and License (PDDL)", "http://www.opendefinition.org/licenses/odc-pddl"),
+    "notspecified" => LicenceInfo.new("License Not Specified"),
     "odc-by" => LicenceInfo.new("Open Data Commons Attribution License", "http://www.opendefinition.org/licenses/odc-by"),
+    "odc-odbl" => LicenceInfo.new("Open Data Commons Open Database License (ODbL)", "http://www.opendefinition.org/licenses/odc-odbl"),
+    "odc-pddl" => LicenceInfo.new("Open Data Commons Public Domain Dedication and License (PDDL)", "http://www.opendefinition.org/licenses/odc-pddl"),
+    "other-closed" => LicenceInfo.new("Other (Not Open)"),
+    "other-nc" => LicenceInfo.new("Other (Non-Commercial)"),
+    "other-open" => LicenceInfo.new("Other (Open)"),
+    "other-pd" => LicenceInfo.new("Other (Public Domain)"),
+    "uk-ogl" => LicenceInfo.new("Open Government Licence", "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"),
   }
 
-  def self.lookup(licence_id)
-    LICENCES.fetch(licence_id, LicenceInfo.new)
+  def self.lookup(licence_code)
+    LICENCES.fetch(licence_code, LicenceInfo.new)
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -158,14 +158,11 @@ class Legacy::DatasetImportService
   end
 
   def build_licence
-    return 'no-licence' if licence.blank?
-    return 'other' if licence != "uk-ogl"
-    licence
+    legacy_dataset["license_id"]
   end
 
   def build_licence_other
-    return nil if licence.blank?
-    return licence if licence != "uk-ogl"
+    get_extra('licence')
   end
 
   # Converts a legacy frequency into a new-style frequency
@@ -262,9 +259,5 @@ class Legacy::DatasetImportService
 
   def extras
     legacy_dataset.fetch("extras", [])
-  end
-
-  def licence
-    legacy_dataset["license_id"]
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -48,7 +48,7 @@ class Legacy::DatasetImportService
       licence_code: build_licence_code,
       licence_title: licence_info.title,
       licence_url: licence_info.url,
-      licence_custom: get_extra("licence", default: nil),
+      licence_custom: get_extra("licence"),
       topic_id: build_topic_id,
       secondary_topic_id: build_secondary_topic_id,
       status: "published"
@@ -175,9 +175,7 @@ class Legacy::DatasetImportService
   end
 
   def build_licence_code
-    code = legacy_dataset["license_id"]
-    return nil if code == ""
-    code
+    licence
   end
 
   # Converts a legacy frequency into a new-style frequency
@@ -277,6 +275,6 @@ class Legacy::DatasetImportService
   end
 
   def licence
-    legacy_dataset["license_id"]
+    legacy_dataset["license_id"].presence
   end
 end

--- a/db/migrate/2018041810194100_add_new_licence_fields.rb
+++ b/db/migrate/2018041810194100_add_new_licence_fields.rb
@@ -1,0 +1,8 @@
+class AddNewLicenceFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :licence_code, :string
+    add_column :datasets, :licence_title, :string
+    add_column :datasets, :licence_url, :text
+    add_column :datasets, :licence_custom, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018041310444200) do
+ActiveRecord::Schema.define(version: 2018041810194100) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -103,6 +103,10 @@ ActiveRecord::Schema.define(version: 2018041310444200) do
     t.string "short_id"
     t.integer "topic_id"
     t.integer "secondary_topic_id"
+    t.string "licence_code"
+    t.string "licence_title"
+    t.text "licence_url"
+    t.text "licence_custom"
     t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end

--- a/docs/arch/0001-licences.md
+++ b/docs/arch/0001-licences.md
@@ -1,0 +1,37 @@
+# Decision record: Handling licences
+
+Date: 2018-04-18
+
+## Context
+
+Licences stored in the legacy system are messy, allowing selection from a predefined list, entry of a custom licence, or a combination of both. This leads to complexity in determining what should be shown, and how to handle the presentation of large custom licences.
+
+Currently this is handled by two fields in 'Publish'.  The licence field holds the legacy database's `license_id` field. In cases where the `license_id` field has a value of `__other__` then the `license_id` is stored in the `licence_other` field of our Dataset model. The legacy system's custom licence field is ignored entirely.
+
+Publishing users expect that any custom licence information they provide will be stored, and shown in the user interface of [Find data](https://github.com/alphagov/datagovuk_find).
+
+## Decision
+
+We will simplify the storing of licence information to:
+
+* Store the legacy `licence_id` field in the new `licence` field and only index the short licence identifier, e.g. uk-ogl
+* Store the legacy custom licence field (in the `dataset[extras]` record where `key="licence"`) in `licence_other`
+
+It is expected this will be used by the presentation layer by looking up the `licence` field in a table that contains both the title and the url (if any).
+
+**licence but no licence_other**
+
+The `licence` field will be used to find the title and url of the licence, and this will be displayed.
+
+**licence_other and no licence**
+
+The custom licence in `licence_other` will be displayed, and truncated if it is too long. Some custom licences are just a block of HTML, some are HTML followed by text/markdown and some are just text/markdown.
+
+**licence and licence_other**
+
+The `licence` field will be used to find the title and the url of the licence, and this will be displayed.  The custom licence will also be displayed, but truncated as above.
+
+
+## Consequences
+
+This will introduce some difficulty in deploying changes to a running system, where currently the `licence_other` field contains a legacy licence id.

--- a/docs/arch/0001-licences.md
+++ b/docs/arch/0001-licences.md
@@ -14,24 +14,13 @@ Publishing users expect that any custom licence information they provide will be
 
 We will simplify the storing of licence information to:
 
-* Store the legacy `licence_id` field in the new `licence` field and only index the short licence identifier, e.g. uk-ogl
-* Store the legacy custom licence field (in the `dataset[extras]` record where `key="licence"`) in `licence_other`
-
-It is expected this will be used by the presentation layer by looking up the `licence` field in a table that contains both the title and the url (if any).
-
-**licence but no licence_other**
-
-The `licence` field will be used to find the title and url of the licence, and this will be displayed.
-
-**licence_other and no licence**
-
-The custom licence in `licence_other` will be displayed, and truncated if it is too long. Some custom licences are just a block of HTML, some are HTML followed by text/markdown and some are just text/markdown.
-
-**licence and licence_other**
-
-The `licence` field will be used to find the title and the url of the licence, and this will be displayed.  The custom licence will also be displayed, but truncated as above.
+* Create new fields `licence_code`, `licence_title`, `licence_url`, and `licence_custom`
+* Publish will continue (temporarily) fill the old fields so we can migrate the frontend
+* We should remove the `licence` and `licence_other` fields once both publish and find apps are using the new fields.
 
 
 ## Consequences
 
 This will introduce some difficulty in deploying changes to a running system, where currently the `licence_other` field contains a legacy licence id.
+
+We will take a staged approach of adding new fields, changing the frontend and then removing the old fields from publish.

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -137,6 +137,15 @@
       "id": "fe4df876-6aac-43d7-8fa4-e898504b685c"
     },
     {
+      "package_id": "ed24a0eb-a042-4582-9465-2e09fdb63823",
+      "value": "Custom licence",
+      "revision_timestamp": "2016-08-24T11:19:10.782923",
+      "state": "active",
+      "key": "licence",
+      "revision_id": "643e58ba-3eda-4999-9697-337b50558023",
+      "id": "fe4df876-6aac-43d7-8fa4-e898504b6823"
+    },
+    {
       "package_id": "ed24a0eb-a042-4582-9465-2e09fdb6384a",
       "value": "",
       "revision_timestamp": "2016-08-24T11:19:10.782936",

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -21,7 +21,7 @@
   "state": "active",
   "version": null,
   "temporal_coverage-to": "",
-  "license_id": "other",
+  "license_id": "uk-ogl",
   "foi-name": "",
   "foi-email": "",
   "foi-web": "",

--- a/spec/fixtures/legacy_dataset_no_licence.json
+++ b/spec/fixtures/legacy_dataset_no_licence.json
@@ -1,0 +1,149 @@
+{
+    "owner_org": "90aefa0d-0e92-4895-a7fd-c1adb2b3f14f",
+    "title": "Dataset title",
+    "creator_user_id": null,
+    "license_title": "",
+    "temporal_coverage-from": "",
+    "date_updated": "15/9/2011",
+    "relationships_as_object": [],
+    "unpublished": "false",
+    "private": false,
+    "revision_timestamp": "2017-11-06T13:44:05.554071",
+    "id": "ed24a0eb-a042-4582-9465-2e09fdb6384a",
+    "metadata_created": "2011-09-16T15:59:17.535259",
+    "metadata_modified": "2017-11-07T15:44:09.125716",
+    "author": "Local Directgov",
+    "author_email": "author@example.com",
+    "geographic_coverage": [
+      "scotland",
+      "wales"
+    ],
+    "state": "active",
+    "version": null,
+    "temporal_coverage-to": "",
+    "license_id": "",
+    "foi-name": "",
+    "foi-email": "",
+    "foi-web": "",
+    "foi-phone": "",
+    "contact-name": "",
+    "contact-email": "",
+    "contact-phone": "",
+    "update_frequency": "monthly",
+    "revision_id": "197dfecf-32e7-4666-b08a-2e35a9536b16",
+    "date_released": "15/9/2011",
+    "theme-primary": "Business & Economy",
+    "resources": [
+      {
+        "hash": "",
+        "description": "Resource 1 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file_1.csv",
+        "format": "CSV",
+        "date": "3/2016",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e719",
+        "resource_type": "file"
+      },
+      {
+        "hash": "",
+        "description": "Resource 2 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file.html",
+        "format": "html",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
+        "resource_type": "documentation"
+      },
+      {
+        "hash": "",
+        "description": "Resource 3 description",
+        "created": "2017-12-05T09:35:25.928982",
+        "url": "https://example.com/something_maybe",
+        "format": "Some format",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+      }
+    ],
+    "timeseries_resources": [
+      {
+        "hash": "",
+        "description": "Resource 1 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file_1.csv",
+        "date": "2017",
+        "format": "CSV",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e719",
+        "resource_type": "file"
+      }
+    ],
+    "additional_resources": [
+      {
+        "hash": "",
+        "description": "Resource 2 description",
+        "created": "2017-12-04T09:35:25.928982",
+        "url": "https://example.com/file.html",
+        "format": "html",
+        "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
+        "resource_type": "documentation"
+      }
+    ],
+    "tags": [
+      {
+        "vocabulary_id": null,
+        "display_name": "Administration",
+        "name": "Administration",
+        "revision_timestamp": "2013-04-12T13:03:14.657894",
+        "state": "active",
+        "id": "93e47b71-c3ce-4a52-ae65-291915d2a6de"
+      },
+      {
+        "vocabulary_id": null,
+        "display_name": "Government",
+        "name": "Government",
+        "revision_timestamp": "2013-04-12T13:03:14.657894",
+        "state": "active",
+        "id": "bf629917-bdad-469e-9714-9b7d2aa947e5"
+      }
+    ],
+    "organization": {
+      "description": "The Government Digital Service is a team within Cabinet Office tasked with transforming government digital services.\r\nEstablished in response to Martha Lane Fox’s report, ‘Directgov 2010 and beyond: revolution not evolution’, our core purpose is to ensure the Government offers world-class digital products that meet people’s needs.\r\n\r\nhttp://digital.cabinetoffice.gov.uk/category/gds/\r\n\r\n@gdsteam\r\n",
+      "created": "2012-07-12T19:31:11.722062",
+      "title": "Government Digital Service",
+      "name": "government-digital-services",
+      "revision_timestamp": "2017-07-04T16:37:30.526153",
+      "is_organization": true,
+      "state": "active",
+      "image_url": "",
+      "revision_id": "7b41519e-b69f-4cce-8cc7-1528ea667654",
+      "type": "organization",
+      "id": "90aefa0d-0e92-4895-a7fd-c1adb2b3f14f",
+      "approval_status": "pending"
+    },
+    "name": "local_directgov_services",
+    "isopen": false,
+    "url": "http://local.direct.gov.uk/Data/local_authority_service_details.csv",
+    "type": "dataset",
+    "notes": "This dataset is no longer being updated-5000. \r\n\r\nIt has been replaced by a dataset of [URLs to services provided by local authorities](https://data.gov.uk/dataset/local-authority-services). \r\n\r\nIt was last updated on 30 August 2016.\r\n",
+    "register": "false",
+    "theme-secondary": [
+      ""
+    ],
+    "extras": [
+      {
+        "package_id": "ed24a0eb-a042-4582-9465-2e09fdb6384a",
+        "value": "True",
+        "revision_timestamp": "2016-08-24T11:19:10.782936",
+        "state": "active",
+        "key": "UKLP",
+        "revision_id": "643e58ba-3eda-4999-9697-337b50558058",
+        "id": "fe4df876-6aac-43d7-8fa4-e898504b685c"
+      },
+      {
+        "package_id": "ed24a0eb-a042-4582-9465-2e09fdb6384a",
+        "value": "",
+        "revision_timestamp": "2016-08-24T11:19:10.782936",
+        "state": "active",
+        "key": "contact-phone",
+        "revision_id": "643e58ba-3eda-4999-9697-337b50558058",
+        "id": "81a3d92d-66ed-4207-9510-8d96c091b5ff"
+      }
+    ]
+  }

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -152,44 +152,43 @@ describe Legacy::DatasetImportService do
     it "returns the correct topic_id if license has a valid topic" do
       legacy_dataset["theme-primary"] = "Business & Economy"
       topic_id = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_topic_id
-      
+
       expect(topic_id).to eql(1)
     end
 
     it "returns nil if the licence has a missing topic" do
       legacy_dataset["theme-primary"] = ""
       topic_id = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_topic_id
-      
+
       expect(topic_id).to eql(nil)
     end
 
-    it "returns nil if the licence has an invalid topic" do
+    it "returns nil if the dataset has an invalid topic" do
       legacy_dataset["theme-primary"] = "Some invalid topic"
       topic_id = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_topic_id
-      
+
       expect(topic_id).to eql(nil)
     end
   end
 
   describe "#build_licence" do
-    it "returns 'no-license' if licence has no value specified" do
+    it "returns '' if licence has no value specified" do
       legacy_dataset["license_id"] = ""
       licence = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence
-      expect(licence).to eql("no-licence")
+      expect(licence).to eql("")
     end
 
-    it "returns 'other' if the licence is anything other than 'uk-ogl'" do
-      legacy_dataset["license_id"] = "foo"
+    it "returns 'a value' if licence has a value specified" do
+      legacy_dataset["license_id"] = "uk-ogl"
       licence = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence
-      expect(licence).to eql("other")
+      expect(licence).to eql("uk-ogl")
     end
   end
 
   describe "#build_licence_other" do
-    it "returns the name of the licence if it is anything other than 'uk-ogl'" do
-      legacy_dataset["license_id"] = "foo"
+    it "returns a custom licence if one is provided" do
       licence_other = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence_other
-      expect(licence_other).to eql("foo")
+      expect(licence_other).to eql("Custom licence")
     end
   end
 

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -49,7 +49,7 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.licence_code).to be_nil
       expect(imported_dataset.licence_title).to be_nil
       expect(imported_dataset.licence_url).to be_nil
-      expect(imported_dataset.licence_custom).to be_nil
+      expect(imported_dataset.licence_custom).to eql("")
     end
 
     it "creates the datafiles for the imported dataset" do


### PR DESCRIPTION
This PR changes the handling of licences during import so that we have 4 new fields that we can use in bringing Find up to date.

The new fields (licence_code, licence_title, licence_url and licence_custom) will be set on import (either a full import or as a result of `rake import:single_legacy_dataset[environmental-pollution-incidents]`).  

The existing licence fields (licence and licence_other) can continue to be used until the migration is complete.

NB. This does not change the user-interface of Publish, this should be another PR.

https://trello.com/c/EwW9h6EU/12-some-licenses-missing-from-find-dataset-display-l