### PR TITLE
Remove redundant variables from Heroku schema

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,38 +4,8 @@
     "postdeploy": "rake db:migrate ; rake db:seed"
   },
   "env": {
-    "DEVISE_SECRET_KEY": {
-      "required": true
-    },
-    "ES_HOST": {
-      "required": true
-    },
-    "FIND_URL": {
-      "required": true
-    },
-    "HTTP_PASSWORD": {
-      "required": true
-    },
-    "HTTP_USERNAME": {
-      "required": true
-    },
-    "LANG": {
-      "required": true
-    },
-    "RACK_ENV": {
-      "required": true
-    },
-    "RAILS_ENV": {
-      "required": true
-    },
-    "RAILS_LOG_TO_STDOUT": {
-      "required": true
-    },
-    "RAILS_SERVE_STATIC_FILES": {
-      "required": true
-    },
-    "SECRET_KEY_BASE": {
-      "required": true
+    "VCAP_SERVICES": {
+        "required": true
     }
   },
   "formation": {},


### PR DESCRIPTION
    The Heroku deployments have their environment set to staging, so we
    (only) need to populate the VCAP_SERVICES variable to provide all of the
    environment variables.
    
    This is not ideal, and we should look at cleaning up the Heroku
    environment variables, as well as improving the setup to include a
    throwaway elasticsearch.
    
    But this is just a quick fix to unblock the signon work.