### PR TITLE
Add rake task to delete datasets (and associated records)

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -20,9 +20,9 @@ class Dataset < ApplicationRecord
   belongs_to :topic, optional: true
   belongs_to :secondary_topic, optional: true
 
-  has_many :datafiles
-  has_many :docs
-  has_one :inspire_dataset
+  has_many :datafiles, dependent: :destroy
+  has_many :docs, dependent: :destroy
+  has_one :inspire_dataset, dependent: :destroy
 
   validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
     allow_nil: true # To allow creation before setting this value

--- a/lib/tasks/delete.rake
+++ b/lib/tasks/delete.rake
@@ -1,0 +1,34 @@
+require 'csv'
+
+namespace :delete do
+  desc "Delete datasets with legacy_name (or UUID) listed in CSV from stdin"
+  task :datasets => :environment do |_, args|
+    CSV.parse(STDIN.read, :headers => false) do |row|
+      legacy_name_or_uuid = row[0]
+
+      dataset = Dataset.where(legacy_name: legacy_name_or_uuid).
+        or(Dataset.where(uuid: legacy_name_or_uuid)).first
+
+      if dataset.nil?
+        Rails.logger.error "Could not find dataset for #{legacy_name_or_uuid}"
+        next
+      end
+
+      unindex_dataset(dataset.uuid)
+      force_delete_dataset(dataset)
+    end
+  end
+end
+
+def unindex_dataset(uuid)
+  Rails.logger.info "Removing dataset from index #{uuid}"
+  indexer = Legacy::DatasetIndexService.new
+  indexer.remove_from_index(uuid)
+end
+
+def force_delete_dataset(dataset)
+  Rails.logger.info "Deleting dataset #{dataset.name}/#{dataset.legacy_name}/#{dataset.uuid}"
+
+  dataset.status = "draft".freeze
+  dataset.destroy
+end


### PR DESCRIPTION
Allows manual deleting of datasets by streaming a CSV into the rake task
which will process stdin as if it were a CSV.  Each row (containing a
legacy name or a UUID) will be used:

* Find the dataset
* Unindex the dataset
* Delete the dataset and related records

Usage:

```bash
# Delete a single dataset by legacy names (or UUIDs)
echo "naptan" | rake delete:datasets

# Delete a CSV full of dataset legacy names (or UUIDs)
cat to_delete.csv | rake delete:datasets
```

This PR also adds to the dataset model, instructions for Rails on how to
process any dependent objects, in this case, delete them.  This means
any inspire metadata, and any links (docs or datafiles) associated with
the dataset

https://trello.com/c/ihbFAKwe/57-come-up-with-process-to-delete-datasets