### PR TITLE
Fix for missing default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task default: [:spec]
+task default: %i(spec lint)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -6,5 +6,3 @@ task "lint" do
     sh "govuk-lint-ruby --diff --cached --format clang"
   end
 end
-
-Rake::Task[:default].enhance %i(lint)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,8 +1,4 @@
 desc "Run govuk-lint on all files"
 task "lint" do
-  if ENV["CI"]
-    sh "govuk-lint-ruby --diff --cached --format html --out govuk-lint-ruby-${GIT_COMMIT}.html --format clang"
-  else
-    sh "govuk-lint-ruby --diff --cached --format clang"
-  end
+  sh "govuk-lint-ruby --format clang"
 end


### PR DESCRIPTION
To fix deploy failures:

```
rake aborted!
Don't know how to build task 'default' (see --tasks)
```