### PR TITLE
Remove redundant Performance link in site nav

### DIFF
--- a/app/views/layouts/_proposition_header.html.erb
+++ b/app/views/layouts/_proposition_header.html.erb
@@ -11,9 +11,6 @@
               <%= link_to "Manage datasets", manage_path =%>
             </li>
             <li>
-              <%= link_to "Performance", tasks_path =%>
-            </li>
-            <li>
               <%= link_to current_user.try(:name), account_path(current_user.id) =%>
             </li>
             <li>


### PR DESCRIPTION
This link appears to be a placeholder for a feature that was never
implemented. We should remove it to avoid confusion as it just links to
the tasks page.

https://trello.com/c/g66OcJcx/82-performance-tab-doesnt-do-anything