### PR TITLE
Do not index the old licence fields we don't use in Find

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -84,8 +84,6 @@ class Dataset < ApplicationRecord
                 location1
                 location2
                 location3
-                licence
-                licence_other
                 licence_code
                 licence_title
                 licence_url


### PR DESCRIPTION
The licence and licence_other fields are not used in Find anymore, they
have been replaced with 4 new fields that provide better coverage of the
licence metadata we require.  

These new fields are used during import
and we will require further work to change the fields used in the
Publish UI.  See
https://trello.com/c/mP0NcLrY/93-remove-licence-and-licenceother-fields
for more information.