### PR TITLE
Add metadata_last_updated_at attribute to Dataset

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -88,6 +88,7 @@ class Dataset < ApplicationRecord
                 created_at
                 harvested
                 uuid
+                datafile_last_updated_at
             ],
       include: {
         organisation: {},

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -53,6 +53,7 @@ class Legacy::DatasetImportService
       secondary_topic_id: build_secondary_topic_id,
       status: "published",
       datafile_last_updated_at: most_recently_updated_datafile_date,
+      metadata_last_updated_at: legacy_dataset["metadata_modified"],
     }
   end
 

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -51,7 +51,8 @@ class Legacy::DatasetImportService
       licence_custom: get_extra("licence"),
       topic_id: build_topic_id,
       secondary_topic_id: build_secondary_topic_id,
-      status: "published"
+      status: "published",
+      datafile_last_updated_at: most_recently_updated_datafile_date,
     }
   end
 
@@ -276,5 +277,15 @@ private
 
   def licence
     legacy_dataset["license_id"].presence
+  end
+
+  def most_recently_updated_datafile_date
+    dates = []
+
+    legacy_datafiles.each do |datafile|
+      dates << datafile["last_modified_at"] && next if datafile["last_modified_at"]
+      dates << datafile["created"] if datafile["created"]
+    end
+    dates.sort.last if dates.any?
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -104,7 +104,7 @@ class Legacy::DatasetImportService
       format: resource["format"],
       name: datafile_name(resource),
       created_at: resource["created"] || dataset.created_at,
-      updated_at: dataset.last_updated_at
+      updated_at: resource["last_modified_at"] || resource["created"]
     }
   end
 

--- a/db/migrate/20180430095358_add_datafile_last_updated_at_attribute_to_dataset.rb
+++ b/db/migrate/20180430095358_add_datafile_last_updated_at_attribute_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddDatafileLastUpdatedAtAttributeToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :datafile_last_updated_at, :datetime
+  end
+end

--- a/db/migrate/20180501141727_add_metadata_last_updated_at_to_dataset.rb
+++ b/db/migrate/20180501141727_add_metadata_last_updated_at_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddMetadataLastUpdatedAtToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :metadata_last_updated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "licence_title"
     t.text "licence_url"
     t.text "licence_custom"
+    t.datetime "datafile_last_updated_at"
     t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,11 +71,12 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "short_id"
     t.integer "topic_id"
     t.integer "secondary_topic_id"
+    t.datetime "datafile_last_updated_at"
+    t.datetime "metadata_last_updated_at"
     t.string "licence_code"
     t.string "licence_title"
     t.text "licence_url"
     t.text "licence_custom"
-    t.datetime "datafile_last_updated_at"
     t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -42,6 +42,7 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.foi_web).to eql(legacy_dataset["foi-web"])
       expect(imported_dataset.topic_id).to eql(1)
       expect(imported_dataset.datafile_last_updated_at).to eql(parsed_datafile_created_date)
+      expect(imported_dataset.metadata_last_updated_at).to eql(Time.zone.parse(legacy_dataset["metadata_modified"]))
     end
 
     it "sets datafile_last_updated_at so the most recent datafile's last_modified_at when present" do

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -65,18 +65,20 @@ describe Legacy::DatasetImportService do
     end
 
     it "creates the datafiles for the imported dataset" do
+      first_resource = legacy_dataset["resources"][0]
+      first_resource["last_modified_at"] = "2017-12-14T09:35:25.928982"
+
       Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, topics_cache).run
       imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
       imported_datafiles = imported_dataset.links
       first_imported_datafile = imported_datafiles.first
-      first_resource = legacy_dataset["resources"][0]
 
       expect(imported_datafiles.count).to eql(3)
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
       expect(first_imported_datafile.name).to eql(first_resource["description"])
       expect(first_imported_datafile.created_at).to eql(Time.parse(first_resource["created"]))
-      expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
+      expect(first_imported_datafile.updated_at).to eql(Time.parse(first_resource["last_modified_at"]))
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
     end
 


### PR DESCRIPTION
Note: this is branched off https://github.com/alphagov/datagovuk_publish/pull/590.  After it has been merged, this PR will be rebased.

For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

There are instances in Find Data where there is a mismatch between a dataset's "Last updated" timestamp that appears on the search results page and the timestamp that appears on the dataset's own page. We've agreed that the "Last updated" date should reflect the last time a datafile was modified, and if there are no datafiles present then the last modified metadata date should be used. In preparation for this we:

1. Add a `metadata_last_updated_at` timestamp to the Dataset model so we can track this more accurately in future.
2. Modify the dataset importer to set `metadata_last_updated_at` to the `metadata_modified` value provided by the legacy dataset.

A separate PR will be opened to backfill `metadata_last_updated_at` dates for all datasets and a separate card will be written up to deal with setting a value for this attribute when metadata is modified in Publish.

Related PRs: #590 & #592