### PR TITLE
Change last_updated_at on Dataset to public_updated_at

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -88,6 +88,7 @@ class Dataset < ApplicationRecord
                 created_at
                 harvested
                 uuid
+                datafile_last_updated_at
             ],
       include: {
         organisation: {},

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -191,6 +191,8 @@ private
   end
 
   def set_last_updated_date
-    self.last_updated_at = Time.now
+    #TO DO: this needs to be set to the most recently updated datafile update date
+    # or the last modified metadata date
+    self.public_updated_at = Time.now
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -32,7 +32,7 @@ class Legacy::DatasetImportService
       frequency: build_frequency,
       published_date: legacy_dataset["metadata_created"],
       created_at: legacy_dataset["metadata_created"],
-      last_updated_at: legacy_dataset["metadata_modified"],
+      public_updated_at: most_recent_update_date,
       dataset_type: build_type,
       harvested: harvested?,
       contact_name: legacy_dataset["contact-name"],
@@ -53,7 +53,7 @@ class Legacy::DatasetImportService
       secondary_topic_id: build_secondary_topic_id,
       status: "published",
       datafile_last_updated_at: most_recently_updated_datafile_date,
-      metadata_last_updated_at: legacy_dataset["metadata_modified"],
+      metadata_last_updated_at: metadata_last_updated_at,
     }
   end
 
@@ -281,12 +281,27 @@ private
   end
 
   def most_recently_updated_datafile_date
+    @most_recently_updated_datafile_date ||= datafile_update_dates.last if datafile_update_dates
+  end
+
+  def datafile_update_dates
     dates = []
 
     legacy_datafiles.each do |datafile|
       dates << datafile["last_modified_at"] && next if datafile["last_modified_at"]
       dates << datafile["created"] if datafile["created"]
     end
-    dates.sort.last if dates.any?
+
+    dates.sort if dates.any?
+  end
+
+  def metadata_last_updated_at
+    @metadata_last_updated_at ||=
+      legacy_dataset["metadata_modified"] || legacy_dataset["metadata_created"]
+  end
+
+  def most_recent_update_date
+    return most_recently_updated_datafile_date if most_recently_updated_datafile_date.present?
+    metadata_last_updated_at
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -53,6 +53,7 @@ class Legacy::DatasetImportService
       secondary_topic_id: build_secondary_topic_id,
       status: "published",
       datafile_last_updated_at: most_recently_updated_datafile_date,
+      metadata_last_updated_at: legacy_dataset["metadata_modified"],
     }
   end
 

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -51,7 +51,8 @@ class Legacy::DatasetImportService
       licence_custom: get_extra("licence"),
       topic_id: build_topic_id,
       secondary_topic_id: build_secondary_topic_id,
-      status: "published"
+      status: "published",
+      datafile_last_updated_at: most_recently_updated_datafile_date,
     }
   end
 
@@ -276,5 +277,15 @@ private
 
   def licence
     legacy_dataset["license_id"].presence
+  end
+
+  def most_recently_updated_datafile_date
+    dates = []
+
+    legacy_datafiles.each do |datafile|
+      dates << datafile["last_modified_at"] && next if datafile["last_modified_at"]
+      dates << datafile["created"] if datafile["created"]
+    end
+    dates.sort.last if dates.any?
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -104,7 +104,7 @@ class Legacy::DatasetImportService
       format: resource["format"],
       name: datafile_name(resource),
       created_at: resource["created"] || dataset.created_at,
-      updated_at: dataset.last_updated_at
+      updated_at: resource["last_modified_at"] || resource["created"]
     }
   end
 

--- a/db/migrate/20180430095358_add_datafile_last_updated_at_attribute_to_dataset.rb
+++ b/db/migrate/20180430095358_add_datafile_last_updated_at_attribute_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddDatafileLastUpdatedAtAttributeToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :datafile_last_updated_at, :datetime
+  end
+end

--- a/db/migrate/20180501141727_add_metadata_last_updated_at_to_dataset.rb
+++ b/db/migrate/20180501141727_add_metadata_last_updated_at_to_dataset.rb
@@ -1,0 +1,5 @@
+class AddMetadataLastUpdatedAtToDataset < ActiveRecord::Migration[5.1]
+  def change
+    add_column :datasets, :metadata_last_updated_at, :datetime
+  end
+end

--- a/db/migrate/20180501151443_rename_dataset_last_updated_at_to_public_updated_at.rb
+++ b/db/migrate/20180501151443_rename_dataset_last_updated_at_to_public_updated_at.rb
@@ -1,0 +1,5 @@
+class RenameDatasetLastUpdatedAtToPublicUpdatedAt < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :datasets, :last_updated_at, :public_updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "licence_title"
     t.text "licence_url"
     t.text "licence_custom"
+    t.datetime "datafile_last_updated_at"
     t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -71,11 +71,12 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "short_id"
     t.integer "topic_id"
     t.integer "secondary_topic_id"
+    t.datetime "datafile_last_updated_at"
+    t.datetime "metadata_last_updated_at"
     t.string "licence_code"
     t.string "licence_title"
     t.text "licence_url"
     t.text "licence_custom"
-    t.datetime "datafile_last_updated_at"
     t.index ["short_id"], name: "index_datasets_on_short_id", unique: true
     t.index ["uuid"], name: "index_datasets_on_uuid"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,7 +58,7 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid"
-    t.datetime "last_updated_at"
+    t.datetime "public_updated_at"
     t.integer "status", default: 0
     t.string "legacy_name"
     t.string "contact_name"

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -7,6 +7,6 @@ FactoryGirl.define do
     location1 "Westeros"
     frequency "never"
     licence "uk-ogl"
-    last_updated_at Time.now
+    public_updated_at Time.now
   end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -100,13 +100,13 @@ describe Dataset do
     expect(dataset.published_date).to eq publication_date
   end
 
-  it "sets a last_updated_at timestamp when published" do
-    last_updated_at = Time.now
-    allow(Time).to receive(:now).and_return(last_updated_at)
+  it "sets a public_updated_at timestamp when published" do
+    public_updated_at = Time.now
+    allow(Time).to receive(:now).and_return(public_updated_at)
     dataset = FactoryGirl.create(:dataset, datafiles: [FactoryGirl.create(:datafile)])
     dataset.save
     dataset.publish!
 
-    expect(dataset.last_updated_at).to eq last_updated_at
+    expect(dataset.public_updated_at).to eq public_updated_at
   end
 end

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -42,6 +42,7 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.foi_web).to eql(legacy_dataset["foi-web"])
       expect(imported_dataset.topic_id).to eql(1)
       expect(imported_dataset.datafile_last_updated_at).to eql(parsed_datafile_created_date)
+      expect(imported_dataset.metadata_last_updated_at).to eql(Time.zone.parse(legacy_dataset["metadata_modified"]))
     end
 
     it "sets datafile_last_updated_at so the most recent datafile's last_modified_at when present" do

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -65,18 +65,20 @@ describe Legacy::DatasetImportService do
     end
 
     it "creates the datafiles for the imported dataset" do
+      first_resource = legacy_dataset["resources"][0]
+      first_resource["last_modified_at"] = "2017-12-14T09:35:25.928982"
+
       Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, topics_cache).run
       imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
       imported_datafiles = imported_dataset.links
       first_imported_datafile = imported_datafiles.first
-      first_resource = legacy_dataset["resources"][0]
 
       expect(imported_datafiles.count).to eql(3)
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
       expect(first_imported_datafile.name).to eql(first_resource["description"])
       expect(first_imported_datafile.created_at).to eql(Time.parse(first_resource["created"]))
-      expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
+      expect(first_imported_datafile.updated_at).to eql(Time.parse(first_resource["last_modified_at"]))
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
     end
 

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -32,7 +32,7 @@ describe Legacy::DatasetImportService do
       expect(imported_dataset.licence_custom).to eql("Custom licence")
       expect(imported_dataset.published_date).to eq(Time.zone.parse(legacy_dataset["metadata_created"]))
       expect(imported_dataset.created_at).to eq(Time.zone.parse(legacy_dataset["metadata_created"]))
-      expect(imported_dataset.last_updated_at).to eq(Time.zone.parse(legacy_dataset["metadata_modified"]))
+      expect(imported_dataset.public_updated_at).to eq(parsed_datafile_created_date)
       expect(imported_dataset.contact_name).to eql(legacy_dataset["contact-name"])
       expect(imported_dataset.contact_email).to eql(legacy_dataset["contact-email"])
       expect(imported_dataset.contact_phone).to eql(legacy_dataset["contact-phone"])
@@ -52,6 +52,14 @@ describe Legacy::DatasetImportService do
       imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
       parsed_last_modified_date = Time.zone.parse("2017-12-14T09:35:25.928982").utc
       expect(imported_dataset.datafile_last_updated_at).to eql(parsed_last_modified_date)
+    end
+
+    it "sets public_updated_at to metadata_last_updated_at when no datafiles are present" do
+      legacy_dataset["resources"].clear
+      Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, topics_cache).run
+
+      imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
+      expect(imported_dataset.public_updated_at).to eql(imported_dataset.metadata_last_updated_at)
     end
 
     it "correctly sets licence fields where no licence" do


### PR DESCRIPTION
Note: this is branched off #591. After it has been merged, this PR will be rebased.

For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

There are instances in Find Data where there is a mismatch between a dataset's "Last updated" timestamp that appears on the search results page and the timestamp that appears on the dataset's own page. We've agreed that the "Last updated" date should reflect the last time a datafile was modified, and if there are no datafiles present then the last modified metadata date should be used. In preparation for this we:

1. Rename `last_updated_at` on Dataset to `public_updated_at` to reflect that this is a public facing date which will be shown in search results against "Last updated".
2. Update the Dataset Importer service to set `public_updated_at` to the same value as `datafile_last_updated_at`, or in cases where datafiles aren't present set it to the same value as `metdata_last_updated_at`.

A separate PR will deal with backfilling `public_updated_at` and a card will be written to deal with correctly setting `public_updated_at` in Publish.

Related PRs: #590 & #591 
