### PR TITLE
Print logs to STDOUT in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,6 +37,8 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  config.logger = ActiveSupport::Logger.new(STDOUT)
+
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.


### PR DESCRIPTION
Although 'rails s' will send logs to STDOUT and via the specified
logger, our rake tasks only use the logger we set in the environment.
Setting the logger to print to STDOUT in development makes it easier to
see the logging output from rake tasks.