### PR TITLE
Fix alias updater in dev and make it atomic

### DIFF
--- a/spec/services/alias_updater_service_spec.rb
+++ b/spec/services/alias_updater_service_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+describe AliasUpdaterService do
+  let(:client) { double :client }
+
+  subject do
+    described_class.new(new_index_name: "new_index",
+                        index_alias: "my_alias",
+                        client: client,
+                        logger: Rails.logger)
+  end
+
+  describe "#run" do
+    before do
+      allow(client).to receive_message_chain('indices.get_aliases') do
+        { "other_index" => { "aliases" => {} },
+          "current_index" => { "aliases" => { "my_alias" => {} } },
+          "other_alias" => { "aliases" => { "other_alias" => {} } } }
+      end
+    end
+
+    it 'repoints the alias to the new index' do
+      expected = { body: {
+        actions: [
+          { remove: { index: "current_index", alias: "my_alias" } },
+          { add: { index: "new_index", alias: "my_alias" } }
+        ]
+      } }
+
+      expect(client).to receive_message_chain('indices.update_aliases')
+        .with(expected)
+
+      subject.run
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/KsehMWJo/162-fix-reindexing-not-working-in-dev

This has been making https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page more difficult to complete.

The alias updater required an environment variable to specify the
current ES index to replace, which was really annoying to get manually.
Now the current index is determined automatically.

The alias updater used to remove the old alias link and serially and the
new one. A failure at this point would have caused Find to stop working.
Now the alias update (remove old link, add new link) is done atomically.