### PR TITLE
Choose the correct name for data files

### DIFF
--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -127,8 +127,8 @@ class Legacy::DatasetImportService
   end
 
   def datafile_name(resource)
-    name = resource.fetch('name', '').strip
-    name = resource.fetch('description', '').strip if name.blank?
+    name = resource.fetch('name', '').squish
+    name = resource.fetch('description', '').squish if name.blank?
     name.presence || 'No name specified'
   end
 

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -127,7 +127,9 @@ class Legacy::DatasetImportService
   end
 
   def datafile_name(resource)
-    resource['description'].strip == '' ? 'No name specified' : resource['description']
+    name = resource.fetch('name', '').strip
+    name = resource.fetch('description', '').strip if name.blank?
+    name.presence || 'No name specified'
   end
 
   def create_inspire_dataset(dataset_id)

--- a/spec/fixtures/legacy_dataset.json
+++ b/spec/fixtures/legacy_dataset.json
@@ -36,6 +36,7 @@
   "resources": [
     {
       "hash": "",
+      "name": "Resource 1 file name",
       "description": "Resource 1 description",
       "created": "2017-12-04T09:35:25.928982",
       "url": "https://example.com/file_1.csv",
@@ -46,20 +47,22 @@
     },
     {
       "hash": "",
+      "name": "",
+      "description": "",
+      "created": "2017-12-05T09:35:25.928982",
+      "url": "https://example.com/something_maybe",
+      "format": "Some format",
+      "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
+    },
+    {
+      "hash": "",
+      "name": "",
       "description": "Resource 2 description",
       "created": "2017-12-04T09:35:25.928982",
       "url": "https://example.com/file.html",
       "format": "html",
       "id": "e12a256b-893f-44f7-ba49-8dfafe41e718",
       "resource_type": "documentation"
-    },
-    {
-      "hash": "",
-      "description": "Resource 3 description",
-      "created": "2017-12-05T09:35:25.928982",
-      "url": "https://example.com/something_maybe",
-      "format": "Some format",
-      "id": "e12a256b-893f-44f7-ba49-8dfafe41e718"
     }
   ],
   "timeseries_resources": [

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -62,10 +62,13 @@ describe Legacy::DatasetImportService do
       expect(imported_datafiles.count).to eql(3)
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
-      expect(first_imported_datafile.name).to eql(first_resource["description"])
       expect(first_imported_datafile.created_at).to eql(Time.parse(first_resource["created"]))
       expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
+
+      expect(imported_datafiles[0].name).to eql("Resource 1 file name")
+      expect(imported_datafiles[1].name).to eql("No name specified")
+      expect(imported_datafiles[2].name).to eql("Resource 2 description")
     end
 
     it "sets datafile created_at date to resource created date, if present" do


### PR DESCRIPTION
When importing a legacy datafile, the importer was previously just using
the description field.  It should have been checking resource['name']
and only using resource['description'] as a fallback. This resulted in
lots of datasets having links called 'Resource locator' which is a
description of the link, rather than the name.

https://trello.com/c/b9VO8lOm/71-when-syncing-importing-we-end-up-with-links-that-have-no-name-when-they-should