### PR TITLE
Send public_updated_at to elasticsearch

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -89,6 +89,7 @@ class Dataset < ApplicationRecord
                 harvested
                 uuid
             ],
+      methods: :public_updated_at,
       include: {
         organisation: {},
         topic: {},
@@ -168,6 +169,10 @@ class Dataset < ApplicationRecord
     %w[annually quarterly monthly].include?(frequency)
   end
 
+  def public_updated_at
+    most_recently_updated_datafile_timestamp || self.updated_at
+  end
+
 private
 
   def send_to_search_index
@@ -191,5 +196,10 @@ private
 
   def set_last_updated_date
     self.last_updated_at = Time.now
+  end
+
+  def most_recently_updated_datafile_timestamp
+    timestamps = self.datafiles.map(&:updated_at)
+    timestamps.sort.last if timestamps.present?
   end
 end

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -103,7 +103,7 @@ class Legacy::DatasetImportService
       format: resource["format"],
       name: datafile_name(resource),
       created_at: resource["created"] || dataset.created_at,
-      updated_at: dataset.last_updated_at
+      updated_at: resource["last_modified_at"] || resource["created"] || dataset.created_at
     }
   end
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -109,4 +109,18 @@ describe Dataset do
 
     expect(dataset.last_updated_at).to eq last_updated_at
   end
+
+  describe "#public_updated_at" do
+    it "returns the 'updated_at' timestamp for the most recently updated datafile when the dataset has datafiles" do
+      dataset = FactoryGirl.create(:dataset, datafiles: [FactoryGirl.create(:datafile)])
+      datafile_updated_at = dataset.datafiles.first.updated_at
+
+      expect(dataset.public_updated_at).to eq(datafile_updated_at)
+    end
+
+    it "returns the 'updated_at' timestamp for the dataset when the dataset has no datafiles" do
+      dataset = FactoryGirl.create(:dataset)
+      expect(dataset.public_updated_at).to eq(dataset.updated_at)
+    end
+  end
 end

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -53,17 +53,19 @@ describe Legacy::DatasetImportService do
     end
 
     it "creates the datafiles for the imported dataset" do
+      first_resource = legacy_dataset["resources"][0]
+      first_resource["last_modified_at"] = Time.now
+
       Legacy::DatasetImportService.new(legacy_dataset, orgs_cache, topics_cache).run
       imported_dataset = Dataset.find_by(uuid: legacy_dataset["id"])
       imported_datafiles = imported_dataset.links
       first_imported_datafile = imported_datafiles.first
-      first_resource = legacy_dataset["resources"][0]
 
       expect(imported_datafiles.count).to eql(3)
       expect(first_imported_datafile.uuid).to eql(first_resource["id"])
       expect(first_imported_datafile.format).to eql(first_resource["format"])
       expect(first_imported_datafile.created_at).to eql(Time.parse(first_resource["created"]))
-      expect(first_imported_datafile.updated_at).to eql(imported_dataset.last_updated_at)
+      expect(first_imported_datafile.updated_at).to be_within(1.second).of(first_resource["last_modified_at"])
       expect(first_imported_datafile.end_date).to eql(Date.parse(first_resource["date"]).end_of_month)
 
       expect(imported_datafiles[0].name).to eql("Resource 1 file name")


### PR DESCRIPTION
For https://trello.com/c/wQjbYbbv/50-last-updated-different-in-search-results-vs-dataset-page

There are instances in Find Data where there is a mismatch between a dataset's "Last updated" timestamp that appears on the search results page and the timestamp that appears on the dataset's own page. We've agreed that the "Last updated" date should reflect the last time a datafile was modified, and if there are no datafiles present then the date that metadata was last modified should be used. In this PR we present a `public_updated_at` value to the Elasticsearch index which Find Data can use to display a "Last updated" date which satisfies the above logic.