### PR TITLE
Modify CF config to auto-migrate Postgres

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -1,5 +1,6 @@
 applications:
 - name: publish-data-beta
+  command: bundle exec rake db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   env:

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -1,5 +1,6 @@
 applications:
 - name: publish-data-beta-staging
+  command: bundle exec rake db:migrate && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   memory: 512M
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   env:


### PR DESCRIPTION
This is causing unnecessary downtime e.g. for https://trello.com/c/Jy6YRdzO/157-make-orgs-work.

Looks like the default command is here: https://github.com/cloudfoundry/ruby-buildpack/blob/84e9b6ecda79b04c3dd02cd7c369566667c6a028/src/ruby/finalize/release.go