### PR TITLE
Add extra licence options

### DIFF
--- a/app/views/datasets/licences/_licence_options.html.erb
+++ b/app/views/datasets/licences/_licence_options.html.erb
@@ -1,0 +1,49 @@
+<div class="form-group">
+  <fieldset>
+    <legend class="visually-hidden">Choose a licence for this dataset</legend>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Government Licence',
+    value: 'uk-ogl' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Data Commons Attribution License',
+    value: 'odc-by' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Data Commons Open Database License (ODbL)',
+    value: 'odc-odbl' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Creative Commons Attribution',
+    value: 'cc-by' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Creative Commons CCZero',
+    value: 'cc-zero' %>
+
+    <%= dataset_field form, @dataset,
+    target: 'other-licence',
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Other',
+    value: 'other' %>
+
+    <div class="panel panel-border-narrow js-hidden" id="other-licence">
+      <%= dataset_field form, @dataset,
+      input_type: :text_field,
+      name: 'licence_other',
+      label: 'Name of your licence:' %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/datasets/licences/edit.html.erb
+++ b/app/views/datasets/licences/edit.html.erb
@@ -23,32 +23,7 @@
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
   <%= form_for @dataset, url: update_dataset_licence_path(@dataset.uuid, @dataset.name) do |f| %>
-    <div class="form-group">
-      <fieldset>
-        <legend class="visually-hidden">Choose a licence for this dataset</legend>
-
-        <%= dataset_field f, @dataset,
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Open Government Licence',
-        value: 'uk-ogl' %>
-
-        <%= dataset_field f, @dataset,
-        target: 'other-licence',
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Other',
-        value: 'other' %>
-
-        <div class="panel panel-border-narrow js-hidden" id="other-licence">
-          <%= dataset_field f, @dataset,
-          input_type: :text_field,
-          name: 'licence_other',
-          label: 'Name of your licence:' %>
-        </div>
-      </fieldset>
-    </div>
-
+    <%= render partial: 'licence_options', locals: { form: f, dataset: @dataset } %>
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
       <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>

--- a/app/views/datasets/licences/new.html.erb
+++ b/app/views/datasets/licences/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-    Add license -
+  Add license -
 <% end %>
 
 <div class="datasets">
@@ -20,36 +20,10 @@
       </ul>
     </div>
   <% end %>
-
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
   <%= form_for @dataset, url: create_dataset_licence_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
-    <div class="form-group">
-      <fieldset>
-        <legend class="visually-hidden">Choose a licence for this dataset</legend>
-
-        <%= dataset_field f, @dataset,
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Open Government Licence',
-        value: 'uk-ogl' %>
-
-        <%= dataset_field f, @dataset,
-        target: 'other-licence',
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Other',
-        value: 'other' %>
-
-        <div class="panel panel-border-narrow js-hidden" id="other-licence">
-          <%= dataset_field f, @dataset,
-          input_type: :text_field,
-          name: 'licence_other',
-          label: 'Name of your licence:' %>
-        </div>
-      </fieldset>
-    </div>
-
+    <%= render partial: 'licence_options', locals: { form: f, dataset: @dataset } %>
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
       <p><%= link_to 'Skip this step', new_dataset_location_path(@dataset.uuid, @dataset.name) %></p>


### PR DESCRIPTION
https://trello.com/c/XRQKhz80/158-add-additional-licence-fields

This adds the extra licence types, and also pulls the options into a partial so it can be shared between the create and edit flows.