### PR TITLE
Make sure Heroku runs migrations every deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+release: bin/rails db:migrate
 web: bin/rails server -p $PORT -e $RAILS_ENV
 worker: bin/sidekiq


### PR DESCRIPTION
Unfortunately the postdeploy script in app.json only runs when the app is first created. There's apparently no hook for something that runs every time it's deployed, apart from the start command.