### PR TITLE
Fix org mappings for user study migration

### DIFF
--- a/db/migrate/20180503095708_add_user_study_org_mappings.rb
+++ b/db/migrate/20180503095708_add_user_study_org_mappings.rb
@@ -9,7 +9,7 @@ class AddUserStudyOrgMappings < ActiveRecord::Migration[5.1]
     mappings.each do |govuk_content_id, uuid|
       org = Organisation.find_by(uuid: uuid)
       next unless org
-      org.update_attribute(govuk_content_id: govuk_content_id)
+      org.update_attribute(:govuk_content_id, govuk_content_id)
     end
   end
 end


### PR DESCRIPTION
`update_attribute` takes a name, value pair not a hash - http://api.rubyonrails.org/classes/ActiveRecord/Persistence.html#method-i-update_attribute