### PR TITLE
Update view to show additional licence types

### DIFF
--- a/app/views/datasets/licences/_licence_options.html.erb
+++ b/app/views/datasets/licences/_licence_options.html.erb
@@ -1,0 +1,49 @@
+<div class="form-group">
+  <fieldset>
+    <legend class="visually-hidden">Choose a licence for this dataset</legend>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Government Licence',
+    value: 'uk-ogl' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Data Commons Attribution License',
+    value: 'odc-by' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Open Data Commons Open Database License (ODbL)',
+    value: 'odc-odbl' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Creative Commons Attribution',
+    value: 'cc-by' %>
+
+    <%= dataset_field form, @dataset,
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Creative Commons CCZero',
+    value: 'cc-zero' %>
+
+    <%= dataset_field form, @dataset,
+    target: 'other-licence',
+    name: 'licence',
+    input_type: :radio_button,
+    label: 'Other',
+    value: 'other' %>
+
+    <div class="panel panel-border-narrow js-hidden" id="other-licence">
+      <%= dataset_field form, @dataset,
+      input_type: :text_field,
+      name: 'licence_other',
+      label: 'Name of your licence:' %>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/datasets/licences/edit.html.erb
+++ b/app/views/datasets/licences/edit.html.erb
@@ -23,32 +23,7 @@
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
   <%= form_for @dataset, url: update_dataset_licence_path(@dataset.uuid, @dataset.name) do |f| %>
-    <div class="form-group">
-      <fieldset>
-        <legend class="visually-hidden">Choose a licence for this dataset</legend>
-
-        <%= dataset_field f, @dataset,
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Open Government Licence',
-        value: 'uk-ogl' %>
-
-        <%= dataset_field f, @dataset,
-        target: 'other-licence',
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Other',
-        value: 'other' %>
-
-        <div class="panel panel-border-narrow js-hidden" id="other-licence">
-          <%= dataset_field f, @dataset,
-          input_type: :text_field,
-          name: 'licence_other',
-          label: 'Name of your licence:' %>
-        </div>
-      </fieldset>
-    </div>
-
+    <%= render partial: 'licence_options', locals: { form: f, dataset: @dataset } %>
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
       <p><%= link_to 'Cancel', dataset_path(@dataset.uuid, @dataset.name) %></p>

--- a/app/views/datasets/licences/new.html.erb
+++ b/app/views/datasets/licences/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-    Add license -
+  Add license -
 <% end %>
 
 <div class="datasets">
@@ -20,36 +20,10 @@
       </ul>
     </div>
   <% end %>
-
   <h1 class="heading-large">Choose a licence for this dataset</h1>
 
   <%= form_for @dataset, url: create_dataset_licence_path(@dataset.uuid, @dataset.name), method: :post do |f| %>
-    <div class="form-group">
-      <fieldset>
-        <legend class="visually-hidden">Choose a licence for this dataset</legend>
-
-        <%= dataset_field f, @dataset,
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Open Government Licence',
-        value: 'uk-ogl' %>
-
-        <%= dataset_field f, @dataset,
-        target: 'other-licence',
-        name: 'licence',
-        input_type: :radio_button,
-        label: 'Other',
-        value: 'other' %>
-
-        <div class="panel panel-border-narrow js-hidden" id="other-licence">
-          <%= dataset_field f, @dataset,
-          input_type: :text_field,
-          name: 'licence_other',
-          label: 'Name of your licence:' %>
-        </div>
-      </fieldset>
-    </div>
-
+    <%= render partial: 'licence_options', locals: { form: f, dataset: @dataset } %>
     <div class="form-group">
       <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
       <p><%= link_to 'Skip this step', new_dataset_location_path(@dataset.uuid, @dataset.name) %></p>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -68,7 +68,21 @@
             <span class="error-message error">You must choose a licence</span>
           </div>
         <% end %>
-        <%= @dataset.licence == 'uk-ogl' ? 'Open Government Licence' : @dataset.licence_other %>
+        <%= case @dataset.licence
+          when 'uk-ogl'
+            'Open Government Licence'
+          when 'odc-by'
+            "Open Data Commons Attribution License"
+          when 'odc-odbl'
+            'Open Data Commons Open Database License (ODbL)'
+          when 'cc-by'
+            'Creative Commons Attribution'
+          when 'cc-zero'
+            'Creative Commons CCZero'
+          else
+            'Other'
+          end
+        =%>
       </td>
       <td class="dgu-checklist__actions">
         <% if @dataset.licence %>

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -67,13 +67,11 @@ describe 'editing datasets' do
 
     it "should be able to update licence" do
       click_change(:licence)
-      choose(option: 'other')
-      fill_in 'dataset[licence_other]', with: 'MIT'
+      choose(option: 'cc-by')
       click_button 'Save and continue'
 
-      expect(page).to have_content('MIT')
-      expect(last_updated_dataset.licence).to eq('other')
-      expect(last_updated_dataset.licence_other).to eq('MIT')
+      expect(page).to have_content('Creative Commons Attribution')
+      expect(last_updated_dataset.licence).to eq('cc-by')
     end
 
     it "should be able to update location" do


### PR DESCRIPTION
Fix for the blank licence type bug.

We should probably store the types in a config file somewhere and loop through them where we need to display, but this quick fix plugs the gap to get us ready for testing.