### PR TITLE
Improve user journeys for editing a dataset

### DIFF
--- a/app/views/datasets/datafiles/index.html.erb
+++ b/app/views/datasets/datafiles/index.html.erb
@@ -47,16 +47,13 @@
     </tbody>
   </table>
 
-  <p>
-    <%= link_to 'Add another link', new_dataset_datafile_path(@dataset.uuid, @dataset.name), class: "secondary-button" %>
-  </p>
+  <div class="form-group">
+    <p><%= link_to 'Add a link', new_dataset_datafile_path(@dataset.uuid, @dataset.name), class: "secondary-button" %></p>
 
-  <p>
-    <% if @dataset.draft? %>
-      <%= link_to 'Save and continue', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "button" %>
+    <% if @dataset.docs.none? %>
+      <p><%= link_to 'Save and continue', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "button" %></p>
     <% else %>
-      <%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %>
+      <p><%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %></p>
     <% end %>
-  </p>
-
+  </div>
 </main>

--- a/app/views/datasets/docs/index.html.erb
+++ b/app/views/datasets/docs/index.html.erb
@@ -47,11 +47,8 @@
     </tbody>
   </table>
 
-  <p>
-    <%= link_to 'Add another link', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "secondary-button" %>
-  </p>
-
-  <p>
-    <%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %>
-  </p>
+  <div class="form-group">
+    <p><%= link_to 'Add a link', new_dataset_doc_path(@dataset.uuid, @dataset.name), class: "secondary-button" %></p>
+    <p><%= link_to 'Save and continue', dataset_path(@dataset.uuid, @dataset.name), class: "button" %></p>
+  </div>
 </main>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -133,11 +133,7 @@
         <% end %>
       </td>
       <td class="dgu-checklist__actions">
-        <% if @dataset.datafiles.any? %>
-          <%= link_to 'Change', dataset_datafiles_path(@dataset.uuid, @dataset.name) %>
-        <% else %>
-          <%= link_to 'Add', new_dataset_datafile_path(@dataset.uuid, @dataset.name) %>
-        <% end %>
+        <%= link_to 'Change', dataset_datafiles_path(@dataset.uuid, @dataset.name) %>
       </td>
     </tr>
     <tr>
@@ -146,11 +142,7 @@
         <%= link_to doc.name, doc.url %>
       <% end %>
       <td class="dgu-checklist__actions">
-        <% if @dataset.docs.any? %>
-          <%= link_to 'Change', dataset_docs_path(@dataset.uuid, @dataset.name) %>
-        <% else %>
-          <%= link_to 'Add', new_dataset_doc_path(@dataset.uuid, @dataset.name) %>
-        <% end %>
+        <%= link_to 'Change', dataset_docs_path(@dataset.uuid, @dataset.name) %>
       </td>
     </tr>
   </tbody>

--- a/spec/features/datafile_spec.rb
+++ b/spec/features/datafile_spec.rb
@@ -25,7 +25,7 @@ describe 'datafiles' do
     click_change(:datalinks)
     expect(page).to have_content(datafile.name)
 
-    click_link 'Add another link'
+    click_link 'Add a link'
     fill_in 'datafile[url]', with: 'http://google.com'
     fill_in 'datafile[name]', with: 'my other test file'
     click_button 'Save and continue'
@@ -65,7 +65,7 @@ describe 'datafiles' do
     click_change(:documentation)
     expect(page).to have_content(doc.name)
 
-    click_link 'Add another link'
+    click_link 'Add a link'
     fill_in 'doc[url]', with: 'http://google.com/doc'
     fill_in 'doc[name]', with: 'my other test doc'
     click_button 'Save and continue'


### PR DESCRIPTION
https://trello.com/c/Rw90WNqS/169-add-missing-cancel-buttons-for-all-wizard-edit-pages

Editing a dataset currently takes a similar journey to the initial
creation wizard, without the ability to cancel when you try to add a
datafile or doc; showing 'Skip this step' in the context of adding a
datafile or doc also doesn't make sense. This is fixed by changing the
dataset page to remove the 'Add Data' link for datafiles and docs. A
user can still add a new datafile or doc via the 'Change' button, which
takes them to a list of all datafiles of docs with a link to add a new
one. Seeing 'Skip this step' in this context makes more sense because of
the multi-click journey to get to the page.

Clicking 'Save and continue' after a adding a datafile currently prompts
the user to add a doc unless the dataset is published, which seems
arbitrary. This is made better by only prompting if there is no doc.