### PR TITLE
Fixes an error if LEGACY_HOST ends with a /

### DIFF
--- a/app/services/legacy/api_service.rb
+++ b/app/services/legacy/api_service.rb
@@ -14,7 +14,7 @@ private
 
   def build_url(path)
     host = ENV.fetch("LEGACY_HOST", "https://data.gov.uk")
-    "#{host}#{path}"
+    URI.join(host, path).to_s
   end
 
   def call_api(path, parameters)


### PR DESCRIPTION
In some cases the LEGACY_HOST ends with a /, so just concatenating the
path doesn't work.