### PR TITLE
Document optional vars for using signon

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,6 +15,15 @@
     },
     "FIND_URL": {
       "required": true
+    },
+    "OAUTH_ID": {
+      "required": false
+    },
+    "OAUTH_SECRET": {
+      "required": false
+    },
+    "PLEK_SERVICE_SIGNON_URI": {
+      "required": false
     }
   },
   "formation": {


### PR DESCRIPTION
These vars are only required when GDS SSO is configured to use the
'real' strategy, so they're optional but a little tricky to find.