### PR TITLE
Rake task to reset all of the datasets for a single organisation

### DIFF
--- a/app/services/legacy/api_service.rb
+++ b/app/services/legacy/api_service.rb
@@ -1,9 +1,14 @@
 class Legacy::APIService
+  PACKAGE_SEARCH_PATH = '/api/3/action/package_search'.freeze
   PACKAGE_SHOW_PATH = '/api/3/action/package_show'.freeze
   PUBLISHER_SHOW_PATH = '/api/3/action/publisher_show'.freeze
 
   def dataset_show(dataset_id)
     call_api(PACKAGE_SHOW_PATH, id: dataset_id)
+  end
+
+  def dataset_search(query, field_query = '', limit = 1000, offset = 0)
+    call_api(PACKAGE_SEARCH_PATH, q: query, fq: field_query, rows: limit, start: offset)
   end
 
   def publisher_show(publisher_id)


### PR DESCRIPTION
As we encounter issues with the synchronisation, we occassionally get
publishers running their harvester and ending up with 1400 datasets that
have not synced to publish, and fall outside the window within which we
check for changes.

Running this task, with the short name of an organisation, and a boolean
will:

* Delete all the datasets for the organisation if the boolean is "true"
* Re-import all of the datasets for the organisation from the legacy API

There is no transaction, if the container runs out of memory half way
through, you need to run it again! This should only be used in dire
emergencies.