### PR TITLE
Replace PLEK URI override with GOVUK app domain

### DIFF
--- a/app.json
+++ b/app.json
@@ -22,8 +22,8 @@
     "OAUTH_SECRET": {
       "required": false
     },
-    "PLEK_SERVICE_SIGNON_URI": {
-      "required": false
+    "GOVUK_APP_DOMAIN": {
+      "required": true
     }
   },
   "formation": {


### PR DESCRIPTION
https://trello.com/b/a30DSRUe/dgu-q1-doing

Rather than specifying a custom URI for signon, PLEK expects a variable
called GOVUK_APP_DOMAIN to be set, which it will then use to build the
signon URI and any other URIs.