### PR TITLE
Speed up indexing by prefetching records

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -152,7 +152,7 @@ class DatasetsIndexerService
     number_datasets_processed = 0
 
     create_new_index
-    Dataset.published.find_in_batches(batch_size: batch_size) do |datasets|
+    Dataset.published.includes(:organisation, :topic, :inspire_dataset, :datafiles, :docs).find_in_batches(batch_size: batch_size) do |datasets|
       logger.info "Batching #{datasets.length} datasets"
       bulk_index(datasets)
       number_datasets_processed += batch_size


### PR DESCRIPTION
When we reindex the entire database, it is very slow.  By pre-fetching
records (ActiveRecord changes the includes call into an eager_load
because of the where clause) less time is spent querying the database.

By changing the batch size `rake search:reindex[100]` to something 
larger than the default (50) it can be increased significantly. A batch size 
of 500, although using nearly 400Mb of RAM will complete in about 4m.
A batch size of 100 takes about 5 minutes.
