### PR TITLE
Fixes urlvalidator to handle network errors

### DIFF
--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -27,12 +27,21 @@ class UrlValidator < ActiveModel::Validator
   end
 
   def valid_path?(record)
+    error = nil
+
     begin
       RestClient.head record.url
+      return true
     rescue RestClient::ExceptionWithResponse
       error = 'Url path is not valid'
-      create_validation_error(record, error)
+    rescue SocketError
+      error = 'There was a problem connecting to the server'
+    rescue Errno::ECONNREFUSED
+      error = 'The server refused a connection attempt'
     end
+
+    create_validation_error(record, error) if error.present?
+    false
   end
 
   def create_validation_error(record, error)

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -35,18 +35,27 @@ RSpec.describe UrlValidator do
         expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE
       end
 
-      it 'the host does not exist' do
-        url = "http://thishostdoesnotexist.com/data"
+      it 'the url path does not exist' do
+        url = "http://thispathdoesnotexist.com/data"
         stub_request(:any, url).to_return(status: 404)
         subject.url = url
         subject.validate
         expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE
       end
 
-      it 'the url path does not exist' do
+      it 'the host does not exists' do
         # allow_any_instance_of(UrlValidator).to receive(:validPath?).and_return(false)
         url = "http://thishostdoesnotexist.com/data"
-        stub_request(:any, url).to_return(status: 404)
+        stub_request(:any, url).to_raise(SocketError)
+        subject.url = url
+        subject.validate
+        expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE
+      end
+
+      it 'the host refuses the connection' do
+        # allow_any_instance_of(UrlValidator).to receive(:validPath?).and_return(false)
+        url = "http://flakey.website/data"
+        stub_request(:any, url).to_raise(Errno::ECONNREFUSED)
         subject.url = url
         subject.validate
         expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE


### PR DESCRIPTION
The validator was not correctly handling the cases where there was a
network level failure (broken read/write, dns failure etc).