### PR TITLE
Export dataset released status to ES

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -61,8 +61,7 @@ class Dataset < ApplicationRecord
   # What we actually want to index in Elastic, rather than the whole
   # dataset.
   def as_indexed_json(_options = {})
-    as_json(
-      only: %i[
+    as_json(only: %i[
                 name
                 legacy_name
                 title
@@ -89,15 +88,17 @@ class Dataset < ApplicationRecord
                 harvested
                 uuid
             ],
-      methods: :public_updated_at,
-      include: {
-        organisation: {},
-        topic: {},
-        datafiles: {},
-        docs: {},
-        inspire_dataset: {}
-      }
-    )
+          methods: %i[
+            public_updated_at
+            released
+          ],
+          include: {
+            organisation: {},
+            topic: {},
+            datafiles: {},
+            docs: {},
+            inspire_dataset: {}
+          })
   end
 
   def owner
@@ -171,6 +172,10 @@ class Dataset < ApplicationRecord
 
   def public_updated_at
     most_recently_updated_datafile_timestamp || self.updated_at
+  end
+
+  def released
+    links.count.positive?
   end
 
 private

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -9,5 +9,13 @@ FactoryGirl.define do
     licence "uk-ogl"
     topic
     last_updated_at Time.now
+
+    trait :with_datafile do
+      datafiles { create_list(:datafile, 1) }
+    end
+
+    trait :with_doc do
+      docs { create_list(:doc, 1) }
+    end
   end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -123,4 +123,19 @@ describe Dataset do
       expect(dataset.public_updated_at).to eq(dataset.updated_at)
     end
   end
+
+  describe "#released" do
+    it "returns true when there is a link" do
+      dataset = FactoryGirl.create(:dataset, :with_datafile)
+      expect(dataset.released).to be_truthy
+
+      dataset = FactoryGirl.create(:dataset, :with_doc)
+      expect(dataset.released).to be_truthy
+    end
+
+    it "returns false when there is no link" do
+      dataset = FactoryGirl.create(:dataset)
+      expect(dataset.released).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/SkQ9KxWf/139-show-availability-of-datasets-in-search-results

Previously Find would try to infer the dataset released status by using
the count of links. However, the nested link documents are not returned
for certain queries, meaning the released status could not be
determined. Exporting the attribute as a static value solves this
problem.