### PR TITLE
Fixes some problems with non-perfectly-formed URLs

### DIFF
--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -31,12 +31,12 @@ class UrlValidator < ActiveModel::Validator
   end
 
   def encoded?(original_url)
-    decoded = Addressable::URI.unescape(original_url)
+    decoded = Addressable::URI.unencode(original_url)
     decoded != original_url
   end
 
   def encoded_url(url)
-    return Addressable::URI.escape(url) if encoded?(url)
+    return Addressable::URI.encode(url) if encoded?(url)
     url
   end
 

--- a/lib/validators/url_validator.rb
+++ b/lib/validators/url_validator.rb
@@ -1,3 +1,4 @@
+require 'addressable/uri'
 require 'whois-parser'
 require 'rest-client'
 require 'logger'
@@ -17,18 +18,31 @@ class UrlValidator < ActiveModel::Validator
   end
 
   def url_starts_with_protocol?(record)
-    error = 'Url does not start with http or https'
+    uri = Addressable::URI.parse(record.url)
+    return false if uri.blank?
 
-    if record.url !~ /^https?/
+    error = 'Url does not start with http, https, or ftp'
+
+    if %w(http https ftp).exclude? uri.scheme
       create_validation_error(record, error)
     else
       true
     end
   end
 
+  def encoded?(original_url)
+    decoded = Addressable::URI.unescape(original_url)
+    decoded != original_url
+  end
+
+  def encoded_url(url)
+    return Addressable::URI.escape(url) if encoded?(url)
+    url
+  end
+
   def valid_path?(record)
     begin
-      RestClient.head record.url
+      RestClient.head encoded_url(record.url)
     rescue RestClient::ExceptionWithResponse
       error = 'Url path is not valid'
       create_validation_error(record, error)

--- a/spec/validators/url_validator_spec.rb
+++ b/spec/validators/url_validator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe UrlValidator do
         expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE
       end
 
-      it 'the url does not start with \'http\' or \'https\'' do
+      it 'the url does not start with \'http\' or \'https\' or \'ftp\'' do
         subject.url = 'google.com'
         subject.validate
         expect(subject.errors[:url]).to include EXPECTED_ERROR_MESSAGE
@@ -53,10 +53,32 @@ RSpec.describe UrlValidator do
       end
     end
 
+    describe 'Knows whether a URL is encoded or not' do
+      it 'can tell a string is not encoded' do
+        real_validator = UrlValidator.new
+        source = 'http://test.com/encoded url'
+        expect(real_validator.encoded?(source)).to be_falsey
+      end
+
+      it 'can tell a string is encoded' do
+        real_validator = UrlValidator.new
+        source = 'http://test.com/encoded%20url'
+        expect(real_validator.encoded?(source)).to be_truthy
+      end
+    end
+
     describe 'Does not create validation error' do
       it 'if url is valid' do
         url = 'http://www.bbc.co.uk/news'
         stub_request(:any, url).to_return(status: 404)
+        subject.url = url
+        subject.validate
+        expect(subject.errors[:url]).to be_empty
+      end
+
+      it 'if it has spaces in the URL' do
+        url = "http://thishostdoesnotexist.com/data/file with spaces.csv"
+        stub_request(:any, url).to_return(status: 200)
         subject.url = url
         subject.validate
         expect(subject.errors[:url]).to be_empty


### PR DESCRIPTION
RestClient doesn't like making requests with non-encoded strings, and so
this PR will encode the string, if it is not already. This stops the
validation complaining about URLs the user has given that may contain
spaces.

Also adds ftp to the list of allowed URLs.