### PR TITLE
Stop exporting ES fields that aren't used by Find

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -70,11 +70,9 @@ class Dataset < ApplicationRecord
                 description
                 foi_name
                 foi_email
-                foi_phone
                 foi_web
                 contact_name
                 contact_email
-                contact_phone
                 location1
                 location2
                 location3
@@ -82,9 +80,6 @@ class Dataset < ApplicationRecord
                 licence_title
                 licence_url
                 licence_custom
-                frequency
-                published_date
-                last_updated_at
                 created_at
                 harvested
                 uuid


### PR DESCRIPTION
These fields are not rendered by Find and can be safely removed from the
exported datasets, thus simplifying the (already massive) data model.