### PR TITLE
Remove duplicate error div

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,9 +23,6 @@
     <%= yield %>
   </main>
 
-
-  <div id="global-app-error" class="app-error hidden"></div>
-
   <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
 
 <% end %>


### PR DESCRIPTION
This removes a duplicate div intended to contain error messages, which is already created for us. With two identical divs the pages are not html-compliant. There is no visual change related to this fix.