### PR TITLE
Only validate URLs when creating via the form

### DIFF
--- a/app/controllers/datasets/datafiles_controller.rb
+++ b/app/controllers/datasets/datafiles_controller.rb
@@ -15,7 +15,7 @@ class Datasets::DatafilesController < ApplicationController
   def create
     @datafile = @dataset.datafiles.build(datafile_params)
 
-    if @datafile.save
+    if @datafile.save(context: :link_form)
       redirect_to dataset_datafiles_path(@dataset.uuid, @dataset.name)
     else
       render :new
@@ -25,7 +25,8 @@ class Datasets::DatafilesController < ApplicationController
   def edit; end
 
   def update
-    if @datafile.update(datafile_params)
+    @datafile.assign_attributes(datafile_params)
+    if @datafile.save(context: :link_form)
       redirect_to dataset_datafiles_path(@dataset.uuid, @dataset.name)
     else
       render :edit

--- a/app/controllers/datasets/docs_controller.rb
+++ b/app/controllers/datasets/docs_controller.rb
@@ -13,7 +13,7 @@ class Datasets::DocsController < ApplicationController
   def create
     @doc = @dataset.docs.build(doc_params)
 
-    if @doc.save
+    if @doc.save(context: :link_form)
       redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
     else
       render :new
@@ -23,7 +23,8 @@ class Datasets::DocsController < ApplicationController
   def edit; end
 
   def update
-    if @doc.update(doc_params)
+    @doc.assign_attributes(doc_params)
+    if @doc.save(context: :link_form)
       redirect_to dataset_docs_path(@dataset.uuid, @dataset.name)
     else
       render :edit

--- a/app/controllers/datasets/licences_controller.rb
+++ b/app/controllers/datasets/licences_controller.rb
@@ -13,7 +13,7 @@ class Datasets::LicencesController < ApplicationController
     @dataset = current_dataset
     @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
 
-    if @dataset.save
+    if @dataset.save(context: :dataset_form)
       redirect_to new_dataset_location_path(@dataset.uuid, @dataset.name)
     else
       render :new
@@ -24,7 +24,7 @@ class Datasets::LicencesController < ApplicationController
     @dataset = current_dataset
     @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
 
-    if @dataset.save
+    if @dataset.save(context: :dataset_form)
       redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit

--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -31,7 +31,8 @@ class DatasetsController < ApplicationController
   end
 
   def update
-    if @dataset.update(dataset_params)
+    @dataset.assign_attributes(dataset_params)
+    if @dataset.save(context: :dataset_form)
       redirect_to dataset_path(@dataset.uuid, @dataset.name)
     else
       render :edit

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -4,7 +4,7 @@ class Link < ApplicationRecord
   belongs_to :dataset
 
   validates :name, presence: true
-  validates_with UrlValidator
+  validates_with UrlValidator, on: :link_form
 
   before_save :set_uuid
 


### PR DESCRIPTION
As the UrlValidator causes issues during synchronisation, this PR adds a
validation context so that it is only used when the forms are used.
This means that during import, or sync, the validator will not be used.

As validation contexts aren't forwarded through calls to model.update 
the two steps are separated so that attributes are assigned and the save 
call contains the context.  Some calls to dataset.update were fixed in the 
same way.
