### PR TITLE
Increase worker memory limit on staging/production

### DIFF
--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: publish-data-beta-production-worker
-  memory: 512M
+  memory: 1G
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   command: bundle exec sidekiq
   env:

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: publish-data-beta-staging-worker
-  memory: 512M
+  memory: 1G
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.14
   command: bundle exec sidekiq
   env:


### PR DESCRIPTION
https://trello.com/c/SoMECEgx/311-try-and-sort-out-the-crashing-issues-with-the-sync-worker

CloudFoundry uses Docker to launch containers and constrains their heap
memory to a specified number, within the quota of the plan chosen. This
conflicts with Ruby's GC, which cannot be tuned to keep reserved memory
within a limit - it instead works in terms of object counts.

As it's not possible to stop the issue entirely, we can at least reduce
it's frequency by giving the worker a little more memory.