### PR TITLE
Remove unused licence and licence_other fields

### DIFF
--- a/app/controllers/datasets/licences_controller.rb
+++ b/app/controllers/datasets/licences_controller.rb
@@ -11,7 +11,7 @@ class Datasets::LicencesController < ApplicationController
 
   def create
     @dataset = current_dataset
-    @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
+    @dataset.update_attributes(params.fetch(:dataset, {}).permit(:licence_code))
 
     if @dataset.save(context: :dataset_form)
       redirect_to new_dataset_location_path(@dataset.uuid, @dataset.name)
@@ -22,7 +22,7 @@ class Datasets::LicencesController < ApplicationController
 
   def update
     @dataset = current_dataset
-    @dataset.update_attributes(params.require(:dataset).permit(:licence, :licence_other))
+    @dataset.update_attributes(params.require(:dataset).permit(:licence_code))
 
     if @dataset.save(context: :dataset_form)
       redirect_to dataset_path(@dataset.uuid, @dataset.name)

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -26,8 +26,7 @@ class Dataset < ApplicationRecord
   validate :sluggable_title
   validates :summary, presence: true
   validates :frequency, presence: true, if: :published?
-  validates :licence, presence: true, if: :published?
-  validates :licence_other, presence: true, if: lambda { licence == 'other' }
+  validates :licence_code, presence: { message: 'Please select a licence for your dataset' }, if: :published?
   validates :topic, presence: { message: 'Please choose a topic' }, on: :dataset_form
 
   validate  :is_readonly?, on: :update

--- a/app/services/legacy/dataset_import_service.rb
+++ b/app/services/legacy/dataset_import_service.rb
@@ -43,8 +43,6 @@ class Legacy::DatasetImportService
       foi_phone: legacy_dataset["foi-phone"],
       foi_web: legacy_dataset["foi-web"],
       location1: build_location,
-      licence: build_licence,
-      licence_other: build_licence_other,
       licence_code: build_licence_code,
       licence_title: licence_info.title,
       licence_url: licence_info.url,
@@ -163,17 +161,6 @@ class Legacy::DatasetImportService
   def build_summary(notes)
     return notes if notes && notes != ""
     "No description provided"
-  end
-
-  def build_licence
-    return 'no-licence' if licence.blank?
-    return 'other' if licence != "uk-ogl"
-    licence
-  end
-
-  def build_licence_other
-    return nil if licence.blank?
-    return licence if licence != "uk-ogl"
   end
 
   def build_licence_code

--- a/app/views/datasets/licences/_licence_options.html.erb
+++ b/app/views/datasets/licences/_licence_options.html.erb
@@ -3,47 +3,40 @@
     <legend class="visually-hidden">Choose a licence for this dataset</legend>
 
     <%= dataset_field form, @dataset,
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Open Government Licence',
     value: 'uk-ogl' %>
 
     <%= dataset_field form, @dataset,
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Open Data Commons Attribution License',
     value: 'odc-by' %>
 
     <%= dataset_field form, @dataset,
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Open Data Commons Open Database License (ODbL)',
     value: 'odc-odbl' %>
 
     <%= dataset_field form, @dataset,
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Creative Commons Attribution',
     value: 'cc-by' %>
 
     <%= dataset_field form, @dataset,
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Creative Commons CCZero',
     value: 'cc-zero' %>
 
     <%= dataset_field form, @dataset,
     target: 'other-licence',
-    name: 'licence',
+    name: 'licence_code',
     input_type: :radio_button,
     label: 'Other',
     value: 'other' %>
-
-    <div class="panel panel-border-narrow js-hidden" id="other-licence">
-      <%= dataset_field form, @dataset,
-      input_type: :text_field,
-      name: 'licence_other',
-      label: 'Name of your licence:' %>
-    </div>
   </fieldset>
 </div>

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -79,17 +79,17 @@
     <tr>
       <th class="dgu-checklist__heading">Licence</th>
       <td>
-        <% if @dataset.errors[:licence].any? %>
+        <% if @dataset.errors[:licence_code].any? %>
           <div class="form-group-error" id="licence_form_group">
             <span class="error-message error">You must choose a licence</span>
           </div>
         <% end %>
-        <% if @dataset.licence %>
-          <%= I18n.t "dataset.licence_types.#{@dataset.licence}", default: 'Other' %>
+        <% if @dataset.licence_code %>
+          <%= I18n.t "dataset.licence_types.#{@dataset.licence_code}", default: 'Other' %>
         <% end %>
       </td>
       <td class="dgu-checklist__actions">
-        <% if @dataset.licence %>
+        <% if @dataset.licence_code %>
           <%= link_to 'Change', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>
         <% else %>
           <%= link_to 'Select', edit_dataset_licence_path(@dataset.uuid, @dataset.name) %>

--- a/db/migrate/20180605144307_remove_legacy_licence_fields.rb
+++ b/db/migrate/20180605144307_remove_legacy_licence_fields.rb
@@ -1,0 +1,6 @@
+class RemoveLegacyLicenceFields < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :datasets, :licence
+    remove_column :datasets, :licence_other
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,8 +44,6 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.text "description"
     t.string "dataset_type"
     t.integer "organisation_id"
-    t.string "licence"
-    t.text "licence_other"
     t.string "location1"
     t.string "location2"
     t.string "location3"

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     legacy_name "ye-olde-slug"
     location1 "Westeros"
     frequency "never"
-    licence "uk-ogl"
+    licence_code "uk-ogl"
     topic
     last_updated_at Time.now
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -40,7 +40,7 @@ describe "dataset creation" do
       choose option: "uk-ogl"
       click_button "Save and continue"
 
-      expect(Dataset.last.licence).to eq("uk-ogl")
+      expect(Dataset.last.licence_code).to eq("uk-ogl")
 
       # Page 4: Location
       fill_in "dataset[location1]", with: "Aviation House"
@@ -241,15 +241,6 @@ describe "valid options for topic, licence and area" do
 
     it "skips licence" do
       click_link "Skip this step"
-      expect(page).to have_content("Choose a geographical area")
-    end
-
-    it "selected other licence but didn't specify" do
-      choose option: "other"
-      click_button "Save and continue"
-      expect(page).to have_content("Please type the name of your licence", count: 2)
-      fill_in "dataset[licence_other]", with: "MIT"
-      click_button "Save and continue"
       expect(page).to have_content("Choose a geographical area")
     end
   end

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -78,12 +78,12 @@ describe 'editing datasets' do
     end
 
     it "should be able to update licence" do
-      click_change(:licence)
+      click_change(:licence_code)
       choose(option: 'cc-by')
       click_button 'Save and continue'
 
       expect(page).to have_content('Creative Commons Attribution')
-      expect(last_updated_dataset.licence).to eq('cc-by')
+      expect(last_updated_dataset.licence_code).to eq('cc-by')
     end
 
     it "should be able to update location" do

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -46,7 +46,7 @@ describe Dataset do
 
     dataset.valid?
 
-    expect(dataset.errors[:licence]).to include("Please select a licence for your dataset")
+    expect(dataset.errors[:licence_code]).to include("Please select a licence for your dataset")
     expect(dataset.errors[:frequency]).to include("Please indicate how often this dataset is updated")
   end
 
@@ -56,7 +56,7 @@ describe Dataset do
       summary: "Summary",
       organisation_id: @org.id,
       frequency: "never",
-      licence: "uk-ogl"
+      licence_code: "uk-ogl"
     )
 
     d.save
@@ -72,7 +72,7 @@ describe Dataset do
       summary: "Summary",
       organisation_id: @org.id,
       frequency: "never",
-      licence: "uk-ogl"
+      licence_code: "uk-ogl"
     )
 
     d.save

--- a/spec/services/legacy/dataset_import_service_spec.rb
+++ b/spec/services/legacy/dataset_import_service_spec.rb
@@ -192,28 +192,6 @@ describe Legacy::DatasetImportService do
     end
   end
 
-  describe "#build_licence" do
-    it "returns 'no-license' if licence has no value specified" do
-      legacy_dataset["license_id"] = ""
-      licence = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence
-      expect(licence).to eql("no-licence")
-    end
-
-    it "returns 'other' if the licence is anything other than 'uk-ogl'" do
-      legacy_dataset["license_id"] = "foo"
-      licence = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence
-      expect(licence).to eql("other")
-    end
-  end
-
-  describe "#build_licence_other" do
-    it "returns the name of the licence if it is anything other than 'uk-ogl'" do
-      legacy_dataset["license_id"] = "foo"
-      licence_other = described_class.new(legacy_dataset, orgs_cache, topics_cache).build_licence_other
-      expect(licence_other).to eql("foo")
-    end
-  end
-
   describe "#harvested?" do
     it "is true if legacy dataset has a harvest_object_id" do
       legacy_dataset["extras"] = [{

--- a/spec/support/dataset_helper.rb
+++ b/spec/support/dataset_helper.rb
@@ -8,7 +8,7 @@ def click_change(property)
     summary
     additional_info
     topic
-    licence
+    licence_code
     location
     frequency
     datalinks


### PR DESCRIPTION
https://trello.com/c/IzJCX5UY/337-remove-licence-and-licenceother-fields-from-publish

This fields are replaced with licence_code, licence_title, etc. As prt
of removing these fields, it became clear that the form element to
populate the licence_other field was broken. As the field no longer
exists, it made more sense to remove the redundant code than try and fix
the broken feature, as leaving a reference to licence_other would be
more confusing.