### PR TITLE
Scope dataset validation to only happen in wizard

### DIFF
--- a/app/controllers/datasets/frequencies_controller.rb
+++ b/app/controllers/datasets/frequencies_controller.rb
@@ -9,16 +9,9 @@ class Datasets::FrequenciesController < ApplicationController
 
   def create
     @dataset = current_dataset
+    @dataset.frequency = frequency_params[:frequency]
 
-    begin
-      @dataset.frequency = params.require(:dataset).permit(:frequency)[:frequency]
-    rescue ActionController::ParameterMissing
-      @dataset.errors.add(:frequency, 'Please indicate how often this dataset is updated')
-      render :new
-      return
-    end
-
-    if @dataset.save
+    if @dataset.save(context: :dataset_frequency_form)
       redirect_to new_dataset_datafile_path(@dataset.uuid, @dataset.name)
     else
       render :new
@@ -40,5 +33,9 @@ private
 
   def current_dataset
     Dataset.find_by(uuid: params[:uuid])
+  end
+
+  def frequency_params
+    params.fetch(:dataset, {}).permit(:frequency)
   end
 end

--- a/app/controllers/datasets/licences_controller.rb
+++ b/app/controllers/datasets/licences_controller.rb
@@ -9,9 +9,9 @@ class Datasets::LicencesController < ApplicationController
 
   def create
     @dataset = current_dataset
-    @dataset.update_attributes(params.fetch(:dataset, {}).permit(:licence_code))
+    @dataset.licence_code = licence_params[:licence_code]
 
-    if @dataset.save(context: :dataset_form)
+    if @dataset.save(context: :dataset_licence_form)
       redirect_to new_dataset_location_path(@dataset.uuid, @dataset.name)
     else
       render :new
@@ -33,5 +33,9 @@ private
 
   def current_dataset
     Dataset.find_by(uuid: params[:uuid])
+  end
+
+  def licence_params
+    params.fetch(:dataset, {}).permit(:licence_code)
   end
 end

--- a/app/controllers/datasets/topics_controller.rb
+++ b/app/controllers/datasets/topics_controller.rb
@@ -13,7 +13,7 @@ class Datasets::TopicsController < ApplicationController
     @dataset = current_dataset
     @dataset.topic_id = topic_params[:topic_id]
 
-    if @dataset.save(context: :dataset_form)
+    if @dataset.save(context: :dataset_topic_form)
       redirect_to new_dataset_licence_path(@dataset.uuid, @dataset.name)
     else
       @topics = sorted_topics

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -21,13 +21,11 @@ class Dataset < ApplicationRecord
   has_many :docs, dependent: :destroy
   has_one :inspire_dataset, dependent: :destroy
 
-  validates :frequency, inclusion: { in: %w(daily monthly quarterly annually financial-year never irregular) },
-    allow_nil: true # To allow creation before setting this value
   validate :sluggable_title
   validates :summary, presence: true
-  validates :frequency, presence: true, if: :published?
-  validates :licence_code, presence: { message: 'Please select a licence for your dataset' }, if: :published?
-  validates :topic, presence: { message: 'Please choose a topic' }, on: :dataset_form
+  validates :frequency, presence: { message: 'Please indicate how often this dataset is updated' }, on: :dataset_frequency_form
+  validates :licence_code, presence: { message: 'Please select a licence for your dataset' }, on: :dataset_licence_form
+  validates :topic, presence: { message: 'Please choose a topic' }, on: :dataset_topic_form
 
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, -> { where(status: "published") }

--- a/app/views/datasets/licences/new.html.erb
+++ b/app/views/datasets/licences/new.html.erb
@@ -10,5 +10,4 @@
   <%= render partial: 'licence_options', locals: { form: f, dataset: @dataset } %>
 
   <p><%= f.submit 'Save and continue', class: 'button' %> </br></p>
-  <p><%= link_to 'Skip this step', new_dataset_location_path(@dataset.uuid, @dataset.name) %></p>
 <% end %>

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -234,14 +234,9 @@ describe "valid options for topic, licence and area" do
       expect(page).to have_content("Choose a geographical area")
     end
 
-    it "missing a licence, continue anyway" do
+    it "if missing, throw error" do
       click_button "Save and continue"
-      expect(page).to have_content("Choose a geographical area")
-    end
-
-    it "skips licence" do
-      click_link "Skip this step"
-      expect(page).to have_content("Choose a geographical area")
+      expect(page).to have_content("Please select a licence for your dataset")
     end
   end
 

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -36,36 +36,6 @@ describe Dataset do
     expect(dataset.name).to eq("my-even-better-dataset")
   end
 
-  it "validates more strictly when publishing" do
-    dataset = Dataset.new(
-      title: "dataset",
-      summary: "Summary",
-      organisation_id: @org.id,
-      status: "published"
-    )
-
-    dataset.valid?
-
-    expect(dataset.errors[:licence_code]).to include("Please select a licence for your dataset")
-    expect(dataset.errors[:frequency]).to include("Please indicate how often this dataset is updated")
-  end
-
-  it "can pass strict validation when publishing" do
-    d = Dataset.new(
-      title: "dataset",
-      summary: "Summary",
-      organisation_id: @org.id,
-      frequency: "never",
-      licence_code: "uk-ogl"
-    )
-
-    d.save
-
-    d.datafiles.create(url: "http://127.0.0.1", name: "Datafile link")
-
-    expect(d.published!).to eq(true)
-  end
-
   it "is not possible to delete a published dataset" do
     d = Dataset.new(
       title: "dataset",


### PR DESCRIPTION
https://trello.com/c/JFfTjKko/338-only-validate-licence-frequency-and-topic-when-using-the-wizard

Previously dataset validations would partially occur when the dataset
was published. This would interact badly with the CKAN sync such that
all validations were disabled.

The validations now scoped in contexts specific to the page of the
dataset form they are required on. This meant it was necessary to remove
the 'Skip this step' option for licences.

Some of the controllers were dealing with form parameters in different
ways. In order to ensure the validations were consistent, some of the
controllers have been changed to have the same structure.