### PR TITLE
Remove readonly validation for harvested datasets

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -30,19 +30,11 @@ class Dataset < ApplicationRecord
   validates :licence_other, presence: true, if: lambda { licence == 'other' }
   validates :topic, presence: { message: 'Please choose a topic' }, on: :dataset_form
 
-  validate  :is_readonly?, on: :update
-
   scope :owned_by, ->(creator_id) { where(creator_id: creator_id) }
   scope :published, -> { where(status: "published") }
   scope :with_datafiles, -> { joins(:datafiles) }
   scope :with_no_datafiles, -> { left_outer_joins(:datafiles).where(links: { id: nil }) }
   scope :draft, -> { where(status: "draft") }
-
-  def is_readonly?
-    if persisted? && self.harvested?
-      errors[:base] << 'Harvested datasets cannot be modified.'
-    end
-  end
 
   def links
     datafiles + docs

--- a/app/views/manage/_base.html.erb
+++ b/app/views/manage/_base.html.erb
@@ -36,7 +36,7 @@
           </td>
 
           <td class="dgu-datasets-table__actions">
-            <% unless dataset.is_readonly? %>
+            <% unless dataset.harvested? %>
               <%= link_to 'Add Data', dataset_datafiles_path(dataset.uuid, dataset.name) %>
               <%= link_to 'Edit', dataset_path(dataset.uuid, dataset.name) %><br/>
             <% end %>

--- a/spec/controllers/datasets_controller_spec.rb
+++ b/spec/controllers/datasets_controller_spec.rb
@@ -8,17 +8,6 @@ describe DatasetsController, type: :controller do
     sign_in_as(user)
   end
 
-  it "prevents harvested datasets from being updated through the user interface" do
-    dataset = FactoryGirl.create(:dataset,
-                                 harvested: true)
-
-    patch :update, params: { uuid: dataset.uuid, name: dataset.name, dataset: { title: "New title" } }
-
-    dataset.valid?
-
-    expect(dataset.errors[:base]).to include("Harvested datasets cannot be modified.")
-  end
-
   it "redirects to slugged URL" do
     dataset = FactoryGirl.create(:dataset,
                                  name: "legit-name",


### PR DESCRIPTION
https://trello.com/c/DFd1msUC/347-remove-backend-readonly-validation-for-harvested-datasets

Datasets previously had a read_only validation that was in conflict with
the CKAN sync, as this should be able to update harvested datasets.

It would be difficult to use validation contexts to work around this, as
there are many that could apply and only one (sync) that does not.

Because harvested datasets are not shown to the user, it should be OK to
remove this backend protection as it's unlikely to ever be used.