### PR TITLE
Remove unused dataset and link properties

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -19,6 +19,7 @@ class Dataset < ApplicationRecord
 
   has_many :datafiles, dependent: :destroy
   has_many :docs, dependent: :destroy
+  has_many :links, dependent: :destroy
   has_one :inspire_dataset, dependent: :destroy
 
   validate :sluggable_title
@@ -31,11 +32,6 @@ class Dataset < ApplicationRecord
   scope :published, -> { where(status: "published") }
   scope :with_datafiles, -> { joins(:datafiles) }
   scope :with_no_datafiles, -> { left_outer_joins(:datafiles).where(links: { id: nil }) }
-  scope :draft, -> { where(status: "draft") }
-
-  def links
-    datafiles + docs
-  end
 
   def publish!
     if publishable?
@@ -88,14 +84,6 @@ class Dataset < ApplicationRecord
             docs: {},
             inspire_dataset: {}
           })
-  end
-
-  def owner
-    User.find(id: self.owner_id)
-  end
-
-  def owner=(user)
-    self.owner_id = user.id
   end
 
   def creator
@@ -153,10 +141,6 @@ class Dataset < ApplicationRecord
 
   def never?
     frequency == 'never'
-  end
-
-  def timeseries?
-    %w[annually quarterly monthly].include?(frequency)
   end
 
   def public_updated_at

--- a/db/migrate/20180607110440_remove_unused_dataset_fields.rb
+++ b/db/migrate/20180607110440_remove_unused_dataset_fields.rb
@@ -1,0 +1,6 @@
+class RemoveUnusedDatasetFields < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :datasets, :owner_id
+    remove_column :datasets, :legacy_metadata
+  end
+end

--- a/db/migrate/20180607110616_remove_unused_link_fields.rb
+++ b/db/migrate/20180607110616_remove_unused_link_fields.rb
@@ -1,0 +1,8 @@
+class RemoveUnusedLinkFields < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :links, :size
+    remove_column :links, :last_check
+    remove_column :links, :documentation
+    remove_column :links, :short_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -49,10 +49,8 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "location3"
     t.text "frequency"
     t.integer "creator_id"
-    t.integer "owner_id"
     t.datetime "published_date"
     t.boolean "harvested"
-    t.text "legacy_metadata"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid"
@@ -110,21 +108,16 @@ ActiveRecord::Schema.define(version: 2018042510281100) do
     t.string "name"
     t.text "url"
     t.string "format"
-    t.integer "size"
     t.integer "dataset_id"
     t.date "start_date"
     t.date "end_date"
     t.integer "quarter"
     t.boolean "broken"
-    t.datetime "last_check"
-    t.boolean "documentation"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "uuid"
     t.datetime "last_modified"
     t.string "type"
-    t.string "short_id"
-    t.index ["short_id"], name: "index_links_on_short_id", unique: true
     t.index ["uuid"], name: "index_links_on_uuid"
   end
 

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe "dataset creation" do
   let(:land) { FactoryGirl.create(:organisation, name: 'land-registry', title: 'Land Registry') }
   let!(:user) { FactoryGirl.create(:user, primary_organisation: land) }
-  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land, creator: user, owner: user) }
+  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land, creator: user) }
   let!(:topic) { FactoryGirl.create(:topic) }
 
   context "when the user goes through entire flow" do
@@ -266,7 +266,7 @@ end
 describe "dataset frequency options" do
   let(:land) { FactoryGirl.create(:organisation, name: 'land-registry', title: 'Land Registry') }
   let!(:user) { FactoryGirl.create(:user, primary_organisation: land) }
-  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land, owner: user) }
+  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land) }
 
   before(:each) do
     url = "https://test.data.gov.uk/api/3/action/package_patch"
@@ -419,7 +419,7 @@ end
 describe "passing the frequency page" do
   let(:land) { FactoryGirl.create(:organisation, name: 'land-registry', title: 'Land Registry') }
   let!(:user) { FactoryGirl.create(:user, primary_organisation: land) }
-  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land, owner: user, frequency: nil) }
+  let!(:dataset) { FactoryGirl.create(:dataset, organisation: land, frequency: nil) }
 
   before(:each) do
     url = "https://test.data.gov.uk/api/3/action/package_patch"

--- a/spec/features/datafile_spec.rb
+++ b/spec/features/datafile_spec.rb
@@ -10,8 +10,7 @@ describe 'datafiles' do
                        status: "published",
                        datafiles: [FactoryGirl.create(:datafile)],
                        docs: [FactoryGirl.create(:doc)],
-                       creator: user,
-                       owner: user)
+                       creator: user)
   end
 
   before(:each) do

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -12,7 +12,6 @@ describe 'editing datasets' do
                        datafiles: [FactoryGirl.create(:datafile)],
                        docs: [FactoryGirl.create(:doc)],
                        creator: user,
-                       owner: user,
                        topic: topic)
   end
 
@@ -20,8 +19,7 @@ describe 'editing datasets' do
     FactoryGirl.create(:dataset,
                        organisation: land,
                        status: "draft",
-                       creator: user,
-                       owner: user)
+                       creator: user)
   end
 
   before(:each) do
@@ -130,8 +128,7 @@ describe 'editing datasets' do
 
     it "can publish an incomplete dataset" do
       unfinished_dataset = FactoryGirl.create(:dataset,
-                                               creator: user,
-                                               owner: user)
+                                               creator: user)
 
       visit dataset_url(unfinished_dataset.uuid, unfinished_dataset.name)
       expect(unfinished_dataset).not_to be_published

--- a/spec/features/harvested_dataset_spec.rb
+++ b/spec/features/harvested_dataset_spec.rb
@@ -9,8 +9,7 @@ describe "Harvested datasets" do
                        organisation: land,
                        harvested: true,
                        datafiles: [FactoryGirl.create(:datafile)],
-                       creator: user,
-                       owner: user)
+                       creator: user)
   end
 
   it "should be readonly (no add/edit buttons appear)" do


### PR DESCRIPTION
https://trello.com/c/g07wP2X9/325-remove-old-sync-code-after-replacing-it-with-the-new-sync-code

These aren't used anywhere in the app and should be removed to reduce
confusion when trying to inspect these types of record.