### PR TITLE
Remove invalid publishing logic for datasets

### DIFF
--- a/app/controllers/datasets_controller.rb
+++ b/app/controllers/datasets_controller.rb
@@ -40,40 +40,22 @@ class DatasetsController < ApplicationController
   end
 
   def publish
-    if @dataset.publishable?
-      flash[:success] = if @dataset.published?
-                          I18n.t 'dataset.updated'
-                        else
-                          I18n.t 'dataset.published'
-                        end
+    flash[:success] = I18n.t 'dataset.published'
+    @dataset.publish!
 
-      @dataset.publish!
-
-      flash[:extra] = @dataset
-      redirect_to manage_path
-    else
-      render :show
-    end
+    flash[:extra] = @dataset
+    redirect_to manage_path
   end
 
   def confirm_delete
-    if @dataset.published?
-      @dataset.errors.add(:delete_prevent, 'Published datasets cannot be deleted')
-    else
-      flash[:alert] = 'Are you sure you want to delete this dataset?'
-    end
+    flash[:alert] = 'Are you sure you want to delete this dataset?'
     render :show
   end
 
   def destroy
-    if @dataset.published?
-      @dataset.errors.add(:delete_prevent, 'Published datasets cannot be deleted')
-      render :show
-    else
-      flash[:deleted] = "The dataset '#{@dataset.title}' has been deleted"
-      @dataset.destroy
-      redirect_to manage_path
-    end
+    flash[:deleted] = "The dataset '#{@dataset.title}' has been deleted"
+    @dataset.destroy
+    redirect_to manage_path
   end
 
   def quality

--- a/app/views/datasets/show.html.erb
+++ b/app/views/datasets/show.html.erb
@@ -152,8 +152,5 @@
   <p><%= f.submit @dataset.published? ? "Publish changes" : "Publish", class: 'button' %></p>
 <% end %>
 
-<% unless @dataset.published? %>
-  <p><%= link_to 'Delete this dataset', confirm_delete_dataset_path(@dataset.uuid, @dataset.name), class: 'secondary-button danger' %></p>
-<% end %>
-
+<p><%= link_to 'Delete this dataset', confirm_delete_dataset_path(@dataset.uuid, @dataset.name), class: 'secondary-button danger' %></p>
 <p><%= link_to 'Back to manage your dataset', manage_path, class: 'secondary-button' %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,6 @@
 en:
   dataset:
     published: "Your dataset has been published"
-    updated: "Your dataset has been edited"
     licence_types:
       uk-ogl: Open Government Licence
       odc-by: Open Data Commons Attribution Licence

--- a/spec/features/edit_dataset_spec.rb
+++ b/spec/features/edit_dataset_spec.rb
@@ -107,16 +107,7 @@ describe 'editing datasets' do
       expect(page).to have_selector("input[type=submit][value='Publish changes']")
     end
 
-    it "should not be possible to delete a published dataset" do
-      visit dataset_url(published_dataset.uuid, published_dataset.name)
-      expect(page).to_not have_selector(:css, 'a[href="/datasets/test-title-published/confirm_delete"]')
-      expect(page).to_not have_content('Delete this dataset')
-
-      visit confirm_delete_dataset_path(published_dataset.uuid, published_dataset.name)
-      expect(page).to have_content "Published datasets cannot be deleted"
-    end
-
-    it "should be able to publish a complete dataset" do
+    it "should be able to publish a draft dataset" do
       visit dataset_url(unpublished_dataset.uuid, unpublished_dataset.name)
       expect(unpublished_dataset).not_to be_published
 
@@ -136,17 +127,15 @@ describe 'editing datasets' do
       click_button 'Publish'
       expect(page).to have_content 'Your dataset has been published'
     end
-  end
 
-  context "editing draft datasets from the show page" do
-    it "is possible to delete a draft dataset" do
-      visit dataset_url(unpublished_dataset.uuid, unpublished_dataset.name)
+    it "is possible to delete a dataset" do
+      visit dataset_url(published_dataset.uuid, published_dataset.name)
       click_link 'Delete this dataset'
-      expect(current_path).to eq confirm_delete_dataset_path(unpublished_dataset.uuid, unpublished_dataset.name)
+      expect(current_path).to eq confirm_delete_dataset_path(published_dataset.uuid, published_dataset.name)
       click_link "Yes, delete this dataset"
       expect(current_path).to eq '/manage'
-      expect(page).to have_content "The dataset '#{unpublished_dataset.title}' has been deleted"
-      expect(page).to_not have_selector(:css, 'a[href="/datasets/test-title-unpublished/edit"]')
+      expect(page).to have_content "The dataset '#{published_dataset.title}' has been deleted"
+      expect(page).to_not have_selector(:css, 'a[href="/datasets/test-title-published/edit"]')
     end
   end
 end

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -36,50 +36,6 @@ describe Dataset do
     expect(dataset.name).to eq("my-even-better-dataset")
   end
 
-  it "is not possible to delete a published dataset" do
-    d = Dataset.new(
-      title: "dataset",
-      summary: "Summary",
-      organisation_id: @org.id,
-      frequency: "never",
-      licence_code: "uk-ogl"
-    )
-
-    d.save
-
-    d.datafiles.create(url: "http://127.0.0.1", name: "Test datafile")
-
-    d.published!
-
-    expect { d.destroy }.to raise_exception 'published datasets cannot be deleted'
-    expect(Dataset.count).to eq 1
-
-    d.draft!
-    d.destroy
-
-    expect(Dataset.count).to eq 0
-  end
-
-  it "sets a published_date timestamp when published" do
-    publication_date = Time.now
-    allow(Time).to receive(:now).and_return(publication_date)
-    dataset = FactoryGirl.create(:dataset, datafiles: [FactoryGirl.create(:datafile)])
-    dataset.save
-    dataset.publish!
-
-    expect(dataset.published_date).to eq publication_date
-  end
-
-  it "sets a last_updated_at timestamp when published" do
-    last_updated_at = Time.now
-    allow(Time).to receive(:now).and_return(last_updated_at)
-    dataset = FactoryGirl.create(:dataset, datafiles: [FactoryGirl.create(:datafile)])
-    dataset.save
-    dataset.publish!
-
-    expect(dataset.last_updated_at).to eq last_updated_at
-  end
-
   describe "#public_updated_at" do
     it "returns the 'updated_at' timestamp for the most recently updated datafile when the dataset has datafiles" do
       dataset = FactoryGirl.create(:dataset, datafiles: [FactoryGirl.create(:datafile)])


### PR DESCRIPTION
https://trello.com/c/wpH2Jdt3/356-sync-a-single-dataset-to-find-using-the-ckan-api-26

We should be able to delete a published dataset, so the logic preventing
this has been removed, bringing the behaviour in-line with CKAN sync; a
further piece of work will be necessary to propagate deletions to ES.

The logic for setting the published_date an last_updated_at timestamps
before publishing is also invalid as it implies these timestamps are
required to publish a dataset; in reality, they are not used in Find.