### PR TITLE
Support retry for CKAN import worker

### DIFF
--- a/app/workers/ckan/v26/import_worker.rb
+++ b/app/workers/ckan/v26/import_worker.rb
@@ -5,7 +5,7 @@ module CKAN
     class ImportWorker
       include Sidekiq::Worker
 
-      def perform(package_id)
+      def perform(package_id, *_args)
         package = get_package_from_ckan(package_id)
         dataset = Dataset.find_or_initialize_by(uuid: package_id)
 

--- a/spec/features/ckan_v26_import_spec.rb
+++ b/spec/features/ckan_v26_import_spec.rb
@@ -30,6 +30,15 @@ describe 'ckan import' do
       .to_return(body: package_v26_empty.to_json)
   end
 
+  describe 'govuk sidekiq' do
+    it 'can cope with retries after failure' do
+      context = { "authenticated_user" => nil, "request_id" => nil }
+
+      expect { subject.perform(create_package_id, context) }
+        .to_not raise_error
+    end
+  end
+
   describe 'dataset update' do
     it 'creates a new dataset if it does not exist' do
       expect { subject.perform(create_package_id) }


### PR DESCRIPTION
https://trello.com/c/wpH2Jdt3/356-sync-a-single-dataset-to-find-using-the-ckan-api-26

GOV.UK Sidekiq injects additional context when a Sidekiq job is retried.
In order to ensure the worker can support retry functionality, we need
to support an extra context argument. There seems to be a bug whereby
GOV.UK Sidekiq appends the same context argument every time the job is
retried (instead of replacing the old one) - have raised an issue.