### PR TITLE
Switch to using UUID for ES unique IDs

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -33,12 +33,12 @@ class Dataset < ApplicationRecord
 
   def publish
     published!
-    __elasticsearch__.index_document
+    __elasticsearch__.index_document(id: uuid)
   end
 
   def unpublish
     return unless published?
-    __elasticsearch__.delete_document
+    __elasticsearch__.delete_document(id: uuid)
   end
 
   def as_indexed_json(_options = {})

--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -188,7 +188,7 @@ private
 
   def prepare_records(datasets)
     datasets.map do |dataset|
-      { index: { _id: dataset.id, data: dataset.as_indexed_json } }
+      { index: { _id: dataset.uuid, data: dataset.as_indexed_json } }
     end
   end
 end

--- a/spec/features/ckan_v26_import_spec.rb
+++ b/spec/features/ckan_v26_import_spec.rb
@@ -106,7 +106,7 @@ describe 'ckan import' do
 
     it 'publishes a new dataset to elasticsearch' do
       dataset = Dataset.find_by(uuid: create_package_id)
-      document = get_from_es(dataset.id)
+      document = get_from_es(dataset.uuid)
       expect(document).to eq in_es_format(dataset.as_indexed_json)
     end
 
@@ -115,10 +115,10 @@ describe 'ckan import' do
       dataset.update(title: "foo")
 
       dataset.publish
-      expect(get_from_es(dataset.id)["title"]).to eq "foo"
+      expect(get_from_es(dataset.uuid)["title"]).to eq "foo"
 
       subject.perform(create_package_id)
-      expect(get_from_es(dataset.id)["title"]).to_not eq "foo"
+      expect(get_from_es(dataset.uuid)["title"]).to_not eq "foo"
     end
   end
 end

--- a/spec/features/ckan_v26_sync_spec.rb
+++ b/spec/features/ckan_v26_sync_spec.rb
@@ -74,6 +74,6 @@ describe 'ckan sync' do
     subject.perform
 
     expect(Dataset.all).to_not include dataset_to_delete
-    expect { get_from_es(dataset_to_delete.id) }.to raise_error(/404/)
+    expect { get_from_es(dataset_to_delete.uuid) }.to raise_error(/404/)
   end
 end

--- a/spec/features/dataset_publish_spec.rb
+++ b/spec/features/dataset_publish_spec.rb
@@ -17,7 +17,7 @@ describe "publishing datasets" do
     visit dataset_url(dataset.uuid, dataset.name)
     click_button 'Publish'
 
-    document = get_from_es(dataset.id)
+    document = get_from_es(dataset.uuid)
     expect(document).to eq in_es_format(dataset.reload.as_indexed_json)
   end
 
@@ -29,7 +29,7 @@ describe "publishing datasets" do
     click_button 'Save and continue'
 
     click_button 'Publish'
-    document = get_from_es(dataset.id)
+    document = get_from_es(dataset.uuid)
     expect(document["title"]).to eq 'a new title'
   end
 
@@ -38,7 +38,7 @@ describe "publishing datasets" do
     visit dataset_url(dataset.uuid, dataset.name)
     click_button 'Publish'
 
-    document = get_from_es(dataset.id)
+    document = get_from_es(dataset.uuid)
     expect(document["released"]).to be_falsey
   end
 
@@ -47,7 +47,7 @@ describe "publishing datasets" do
     visit dataset_url(dataset.uuid, dataset.name)
     click_button 'Publish'
 
-    document = get_from_es(dataset.id)
+    document = get_from_es(dataset.uuid)
     expect(document["public_updated_at"]).to eq in_es_format(dataset.reload.updated_at)
   end
 end

--- a/spec/support/es_helper.rb
+++ b/spec/support/es_helper.rb
@@ -1,6 +1,6 @@
-def get_from_es(id)
+def get_from_es(uuid)
   client = Dataset.__elasticsearch__.client
-  client.get(index: Dataset.index_name, id: id)["_source"]
+  client.get(index: Dataset.index_name, id: uuid)["_source"]
 end
 
 def in_es_format(value)


### PR DESCRIPTION
https://trello.com/c/fzYhwLSf/369-use-the-uuid-to-identify-a-dataset-in-elasticsearch-not-a-random-number

The UUID for a dataset should be used everywhere to uniquely identify a
dataset, preventing duplicates and simplifying maintenance and
development tasks where it's necessary to query the ES index directly.