### PR TITLE
Restrict sidekiq web access to localhost

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,10 @@ require 'sidekiq-scheduler/web'
 
 Rails.application.routes.draw do
   root to: 'sessions#new'
+  mount Sidekiq::Web => '/sidekiq', constraints: { domain: 'localhost' }
 
   get 'quality', to: 'home#quality'
   get 'dashboard', to: 'home#dashboard', as: 'dashboard'
-
-  mount Sidekiq::Web => '/sidekiq' unless Rails.env.production?
 
   scope '/datasets' do
     # datafiles


### PR DESCRIPTION
https://trello.com/c/73zsOucF/262-sync-a-single-dataset-to-the-database-using-the-ckan-api-26

Sidekiq Web is now accessible on production but with the restriction
that the request domain must be localhost. This means we can access
Sidekiq Web in production via an SSH tunnel.