### PR TITLE
Fix publish failure due to large summaries

### DIFF
--- a/app/services/datasets_indexer_service.rb
+++ b/app/services/datasets_indexer_service.rb
@@ -39,6 +39,7 @@ class DatasetsIndexerService
             keyword: {
               type: 'keyword',
               index: true,
+              ignore_above: 10000
             },
             english: {
               type: 'text',

--- a/spec/services/datasets_indexer_service_spec.rb
+++ b/spec/services/datasets_indexer_service_spec.rb
@@ -36,6 +36,7 @@ describe DatasetsIndexerService do
               keyword: {
                 type: 'keyword',
                 index: true,
+                ignore_above: 10000
               },
               english: {
                 type: 'text',


### PR DESCRIPTION
https://trello.com/c/wpH2Jdt3/356-sync-a-single-dataset-to-find-using-the-ckan-api-26

A couple of documents have large summaries that are preventing them from
being indexed. We should disable this behaviour for large summaries as
it's unlikely the indexing will be beneficial for so much text.

https://www.elastic.co/guide/en/elasticsearch/reference/current/ignore-above.html