### PR TITLE
Disable Beta Update Worker in production

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,15 +6,3 @@ staging:
     ckan_v26_sync:
       class: CKAN::V26::SyncWorker
       cron: '*/10 * * * *'
-
-production:
-  :queues:
-    - default
-    - importer
-    - indexer
-    - link_checker
-
-  :schedule:
-    beta_update:
-      class: BetaUpdateWorker
-      cron: '0 0 * * * *' # Runs every hour


### PR DESCRIPTION
Takes away the Beta Update Worker so that we can manually rebuild the search index before switching to CKAN::V26::SyncWorker