### PR TITLE
Restrict CKAN sync to only run on staging/prod

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,14 @@
 ---
 :concurrency: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } %>
 
-:schedule:
-  ckan_v26_sync:
-    class: CKAN::V26::SyncWorker
-    cron: '*/10 * * * *'
+staging:
+  :schedule:
+    ckan_v26_sync:
+      class: CKAN::V26::SyncWorker
+      cron: '*/10 * * * *'
+
+production:
+  :schedule:
+    ckan_v26_sync:
+      class: CKAN::V26::SyncWorker
+      cron: '*/10 * * * *'


### PR DESCRIPTION
https://trello.com/c/wpH2Jdt3/356-sync-a-single-dataset-to-find-using-the-ckan-api-26

We don't want it running in development or test. Also, it turns out our
Heroku environment doesn't have enough resources to run the sync job.