### PR TITLE
Add worker to sync CKAN orgs with the local DB

### DIFF
--- a/app/models/ckan/v26/ckan_org.rb
+++ b/app/models/ckan/v26/ckan_org.rb
@@ -1,0 +1,13 @@
+module CKAN
+  module V26
+    class CKANOrg
+      def initialize(resource)
+        @resource = resource
+      end
+
+      def get(key)
+        @resource[key]
+      end
+    end
+  end
+end

--- a/app/services/ckan/v26/ckan_org_differ.rb
+++ b/app/services/ckan/v26/ckan_org_differ.rb
@@ -1,0 +1,32 @@
+require 'ckan/v26/client'
+
+module CKAN
+  module V26
+    class CKANOrgDiffer
+      def call
+        organisation_ids = client.list_organization
+
+        {
+          create_update: organisation_ids,
+          delete: diff_delete(organisation_ids)
+        }
+      end
+
+    private
+
+      def diff_create_update(organisation_ids)
+        organisation_ids
+      end
+
+      def diff_delete(organisation_ids)
+        Organisation.where(govuk_content_id: nil)
+          .where.not(name: organisation_ids).pluck(:name)
+      end
+
+      def client
+        base_url = Rails.configuration.ckan_v26_base_url
+        CKAN::V26::Client.new(base_url: base_url)
+      end
+    end
+  end
+end

--- a/app/services/ckan/v26/organisation_mapper.rb
+++ b/app/services/ckan/v26/organisation_mapper.rb
@@ -1,0 +1,17 @@
+module CKAN
+  module V26
+    class OrganisationMapper
+      def call(ckan_org)
+        {
+          uuid: ckan_org.get("id"),
+          title: ckan_org.get("title"),
+          contact_email: ckan_org.get("contact-email"),
+          contact_name: ckan_org.get("contact-name"),
+          foi_email: ckan_org.get("foi-email"),
+          foi_web: ckan_org.get("foi-web"),
+          foi_name: ckan_org.get("foi-name")
+        }
+      end
+    end
+  end
+end

--- a/app/services/ckan/v26/organisation_updater.rb
+++ b/app/services/ckan/v26/organisation_updater.rb
@@ -1,0 +1,11 @@
+module CKAN
+  module V26
+    class OrganisationUpdater
+      def call(organisation, ckan_org)
+        attributes = OrganisationMapper.new.call(ckan_org)
+        organisation.assign_attributes(attributes)
+        organisation.save
+      end
+    end
+  end
+end

--- a/app/workers/ckan/v26/ckan_org_import_worker.rb
+++ b/app/workers/ckan/v26/ckan_org_import_worker.rb
@@ -1,0 +1,31 @@
+require 'ckan/v26/client'
+
+module CKAN
+  module V26
+    class CKANOrgImportWorker
+      include Sidekiq::Worker
+
+      def perform(organisation_id, *_args)
+        ckan_org = get_organization_from_ckan(organisation_id)
+        organisation = Organisation.find_or_initialize_by(name: organisation_id)
+        update_organisation_from_ckan(ckan_org, organisation)
+      end
+
+    private
+
+      def update_organisation_from_ckan(ckan_org, organisation)
+        Organisation.transaction do
+          OrganisationUpdater.new.call(organisation, ckan_org)
+        end
+      end
+
+      def get_organization_from_ckan(organisation_id)
+        base_url = Rails.configuration.ckan_v26_base_url
+        client = Client.new(base_url: base_url)
+
+        response = client.show_organization(id: organisation_id)
+        CKANOrg.new(response)
+      end
+    end
+  end
+end

--- a/app/workers/ckan/v26/ckan_org_sync_worker.rb
+++ b/app/workers/ckan/v26/ckan_org_sync_worker.rb
@@ -1,0 +1,25 @@
+module CKAN
+  module V26
+    class CKANOrgSyncWorker
+      include Sidekiq::Worker
+
+      def perform
+        actions = CKANOrgDiffer.new.call
+        create_update_organisations(actions[:create_update])
+        delete_old_organisations(actions[:delete])
+      end
+
+    private
+
+      def create_update_organisations(organisation_ids)
+        organisation_ids.each do |organisation_id|
+          CKANOrgImportWorker.perform_async(organisation_id)
+        end
+      end
+
+      def delete_old_organisations(organisation_ids)
+        Organisation.where(name: organisation_ids).destroy_all
+      end
+    end
+  end
+end

--- a/lib/ckan/modules/url_builder.rb
+++ b/lib/ckan/modules/url_builder.rb
@@ -9,7 +9,7 @@ module CKAN
         url
       end
 
-      def build_url(url = @base_url, path:, params:)
+      def build_url(url = @base_url, path:, params: {})
         url = url.clone
         url.path = path
         append_url(url, params: params)

--- a/lib/ckan/v26/client.rb
+++ b/lib/ckan/v26/client.rb
@@ -8,11 +8,23 @@ module CKAN
       include CKAN::Modules::URLBuilder
       include CKAN::Modules::Pagination
 
+      LIST_ORGANIZATION_PATH = "/api/3/action/organization_list".freeze
+      SHOW_ORGANIZATION_PATH = "/api/3/action/organization_show".freeze
       SEARCH_DATASET_PATH = "/api/3/search/dataset".freeze
       SHOW_DATASET_PATH = "/api/3/action/package_show".freeze
 
       def initialize(base_url:)
         @base_url = URI(base_url)
+      end
+
+      def list_organization
+        url = build_url(path: LIST_ORGANIZATION_PATH)
+        JSON.parse(url.read)["result"]
+      end
+
+      def show_organization(id:)
+        url = build_url(path: SHOW_ORGANIZATION_PATH, params: { id: id })
+        JSON.parse(url.read)["result"]
       end
 
       def search_dataset(fl:)

--- a/spec/factories/ckan_v26_ckan_org.rb
+++ b/spec/factories/ckan_v26_ckan_org.rb
@@ -1,0 +1,16 @@
+FactoryGirl.define do
+  factory :ckan_v26_ckan_org, class: CKAN::V26::CKANOrg do
+    id SecureRandom.uuid
+    name "Name"
+
+    add_attribute("contact-name", "Mr. Contact")
+    add_attribute("contact-email", "mr.contact@example.com")
+    add_attribute("foi-name", "Mr. FOI")
+    add_attribute("foi-email", "mr.foi@example.com")
+    add_attribute("foi-web", "http://foi.com")
+
+    initialize_with do
+      CKAN::V26::CKANOrg.new(attributes.stringify_keys)
+    end
+  end
+end

--- a/spec/features/ckan_v26_ckan_org_sync_spec.rb
+++ b/spec/features/ckan_v26_ckan_org_sync_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe 'ckan organisation sync' do
+  subject { CKAN::V26::CKANOrgSyncWorker.new }
+
+  let(:list_organization) { JSON.parse(file_fixture("ckan/v26/list_organization.json").read) }
+  let(:show_organization_create) { JSON.parse(file_fixture("ckan/v26/show_organization_create.json").read) }
+  let(:show_organization_update) { JSON.parse(file_fixture("ckan/v26/show_organization_update.json").read) }
+
+  let(:organisation_to_create_id) { list_organization["result"][0] }
+  let(:organisation_to_update_id) { list_organization["result"][1] }
+
+  let!(:organisation_to_delete) { create :organisation, name: "organisation_to_delete", govuk_content_id: nil }
+  let!(:organisation_to_ignore) { create :organisation, name: "organisation_to_ignore" }
+  let!(:organisation_to_update) { create :organisation, name: organisation_to_update_id }
+
+  before do
+    stub_request(:get, "http://ckan/api/3/action/organization_list")
+      .to_return(body: list_organization.to_json)
+
+    stub_request(:get, "http://ckan/api/3/action/organization_show")
+      .with(query: { id: organisation_to_create_id })
+      .to_return(body: show_organization_create.to_json)
+
+    stub_request(:get, "http://ckan/api/3/action/organization_show")
+      .with(query: { id: organisation_to_update_id })
+      .to_return(body: show_organization_update.to_json)
+  end
+
+  it 'creates new organisations when they appear in ckan' do
+    subject.perform
+    expect(Organisation.pluck(:name)).to include organisation_to_create_id
+  end
+
+  it 'updates existing organisations when they change in ckan' do
+    expect { subject.perform }
+      .to(change { organisation_to_update.reload.updated_at })
+  end
+
+  it 'deletes organisations when they disappear from ckan' do
+    subject.perform
+    expect(Organisation.all).to_not include organisation_to_delete
+  end
+
+  it 'does not delete organisations with a govuk_content_id' do
+    subject.perform
+    expect(Organisation.all).to include organisation_to_ignore
+  end
+end

--- a/spec/fixtures/files/ckan/v26/list_organization.json
+++ b/spec/fixtures/files/ckan/v26/list_organization.json
@@ -1,0 +1,11 @@
+// 20180618150009
+// https://data.gov.uk/api/3/action/organization_list
+
+{
+  "help": "http://data.gov.uk/api/3/action/help_show?name=organization_list",
+  "success": true,
+  "result": [
+    "2gether-nhs-foundation-trust",
+    "aberdeen-city-council"
+  ]
+}

--- a/spec/fixtures/files/ckan/v26/show_organization_create.json
+++ b/spec/fixtures/files/ckan/v26/show_organization_create.json
@@ -1,0 +1,91 @@
+// 20180618150213
+// https://data.gov.uk/api/3/action/organization_show?id=2gether-nhs-foundation-trust
+
+{
+  "help": "http://data.gov.uk/api/3/action/help_show?name=organization_show",
+  "success": true,
+  "result": {
+    "contact-phone": "",
+    "abbreviation": "",
+    "foi-email": "",
+    "id": "f253ec11-900c-45da-86e0-4dd10f5f6b37",
+    "description": "",
+    "category": "nhs",
+    "approval_status": "approved",
+    "title": "2gether NHS Foundation Trust",
+    "foi-web": "http://www.whatdotheyknow.com/body/2gether_nhs_foundation_trust",
+    "users": [
+      {
+        "capacity": "admin",
+        "name": "user_d7180"
+      }
+    ],
+    "contact-email": "",
+    "tags": [
+
+    ],
+    "foi-name": "",
+    "groups": [
+      {
+        "capacity": "public",
+        "name": "national-health-service"
+      }
+    ],
+    "replaced_by": [
+
+    ],
+    "contact-name": "",
+    "name": "2gether-nhs-foundation-trust",
+    "image_display_url": "",
+    "type": "organization",
+    "is_organization": true,
+    "extras": [
+      {
+        "value": "",
+        "key": "abbreviation"
+      },
+      {
+        "value": "nhs",
+        "key": "category"
+      },
+      {
+        "value": "",
+        "key": "contact-email"
+      },
+      {
+        "value": "",
+        "key": "contact-name"
+      },
+      {
+        "value": "",
+        "key": "contact-phone"
+      },
+      {
+        "value": "",
+        "key": "foi-email"
+      },
+      {
+        "value": "",
+        "key": "foi-name"
+      },
+      {
+        "value": "",
+        "key": "foi-phone"
+      },
+      {
+        "value": "http://www.whatdotheyknow.com/body/2gether_nhs_foundation_trust",
+        "key": "foi-web"
+      },
+      {
+        "value": "",
+        "key": "website-name"
+      },
+      {
+        "value": "",
+        "key": "website-url"
+      }
+    ],
+    "image_url": "",
+    "foi-phone": ""
+  }
+}

--- a/spec/fixtures/files/ckan/v26/show_organization_update.json
+++ b/spec/fixtures/files/ckan/v26/show_organization_update.json
@@ -1,0 +1,83 @@
+// 20180618150956
+// https://data.gov.uk/api/3/action/organization_show?id=aberdeen-city-council
+
+{
+  "help": "http://data.gov.uk/api/3/action/help_show?name=organization_show",
+  "success": true,
+  "result": {
+    "contact-phone": "",
+    "abbreviation": "ACC",
+    "foi-email": "",
+    "id": "1cb62be8-50cd-4d87-869d-26dafeb5f649",
+    "description": "Aberdeen City Council",
+    "category": "local-council",
+    "approval_status": "pending",
+    "title": "Aberdeen City Council",
+    "foi-web": "http://www.whatdotheyknow.com/body/aberdeen_city_council",
+    "users": [
+      {
+        "capacity": "admin",
+        "name": "user_d120811"
+      }
+    ],
+    "contact-email": "",
+    "tags": [
+
+    ],
+    "foi-name": "",
+    "groups": [
+      {
+        "capacity": "public",
+        "name": "local-authorities"
+      }
+    ],
+    "replaced_by": [
+
+    ],
+    "contact-name": "",
+    "name": "aberdeen-city-council",
+    "image_display_url": "",
+    "type": "organization",
+    "is_organization": true,
+    "extras": [
+      {
+        "value": "ACC",
+        "key": "abbreviation"
+      },
+      {
+        "value": "local-council",
+        "key": "category"
+      },
+      {
+        "value": "",
+        "key": "contact-email"
+      },
+      {
+        "value": "",
+        "key": "contact-name"
+      },
+      {
+        "value": "",
+        "key": "contact-phone"
+      },
+      {
+        "value": "",
+        "key": "foi-email"
+      },
+      {
+        "value": "",
+        "key": "foi-name"
+      },
+      {
+        "value": "",
+        "key": "foi-phone"
+      },
+      {
+        "value": "http://www.whatdotheyknow.com/body/aberdeen_city_council",
+        "key": "foi-web"
+      }
+    ],
+    "image_url": "",
+    "foi-phone": ""
+  }
+}

--- a/spec/services/ckan/v26/organisation_mapper_spec.rb
+++ b/spec/services/ckan/v26/organisation_mapper_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe CKAN::V26::OrganisationMapper do
+  let(:ckan_org) { build :ckan_v26_ckan_org }
+  let!(:organisation) { create :organisation, name: ckan_org.get("name") }
+
+  describe '#call' do
+    it 'returns the mapped organization attributes for a CKAN org' do
+      attributes = subject.call(ckan_org)
+
+      expect(attributes[:uuid]).to eq ckan_org.get("id")
+      expect(attributes[:contact_name]).to eq ckan_org.get("contact-name")
+      expect(attributes[:contact_email]).to eq ckan_org.get("contact-email")
+      expect(attributes[:foi_name]).to eq ckan_org.get("foi-name")
+      expect(attributes[:foi_email]).to eq ckan_org.get("foi-email")
+      expect(attributes[:foi_web]).to eq ckan_org.get("foi-web")
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/USyQ4NBd/389-sync-a-single-organisation-to-the-database-using-the-ckan-api

The naming conflict between the local 'Organisation' model and the CKAN
'Organization' model is resolved by using 'CKANOrg' to refer to the
latter. Any deletions are scoped to organisations that do not have a
govuk_content_id, as this implies they are accessible in this app.