### PR TITLE
Remove redundant dataset columns

### DIFF
--- a/db/migrate/20180618155007_remove_redundant_dataset_columns.rb
+++ b/db/migrate/20180618155007_remove_redundant_dataset_columns.rb
@@ -1,0 +1,10 @@
+class RemoveRedundantDatasetColumns < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :datasets, :secondary_topic_id
+    remove_column :datasets, :dataset_type
+    remove_column :datasets, :contact_phone
+    remove_column :datasets, :foi_phone
+    remove_column :datasets, :published_date
+    remove_column :datasets, :last_updated_at
+  end
+end


### PR DESCRIPTION
https://trello.com/c/g07wP2X9/325-remove-old-sync-code-after-replacing-it-with-the-new-sync-code

These columns are not used in Publish or Find and can now be safely
removed.