### PR TITLE
Simplify the elastic config (less code, more YML)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,8 +53,6 @@ module PublishDataBeta
     config.autoload_paths += [Rails.root.join("lib/validators")]
     config.autoload_paths += [Rails.root.join("lib/ckan")]
 
-    config.elasticsearch = config_for(:elasticsearch)
-
     config.filter_parameters << :password
     config.filter_parameters << :password_confirmation
   end

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -1,24 +1,24 @@
 default: &default
-  elastic_timeout: 5
+  timeout: 5
 
 test:
   <<: *default
-  host: <%= ENV["ES_HOST"] || "http://localhost:9200" %>
+  host: 'http://localhost:9200'
 
 development:
   <<: *default
-  host: <%= ENV["ES_HOST"] || "http://localhost:9200" %>
+  host: 'http://localhost:9200'
 
 integration:
   <<: *default
-  host: <%= ENV["BONSAI_URL"] %>
+  host: '<%= ENV["BONSAI_URL"] %>'
 
 staging:
   <<: *default
-  host: <%= ENV["ES_HOST"] %>
-  vcap_services: '<%= ENV["VCAP_SERVICES"] %>'
+  host: '<%= JSON.parse(ENV["VCAP_SERVICES"] || "{}")
+                 .dig("elasticsearch", 0, "credentials", "uri") %>'
 
 production:
   <<: *default
-  host: <%= ENV["ES_HOST"] %>
-  vcap_services: '<%= ENV["VCAP_SERVICES"] %>'
+  host: '<%= JSON.parse(ENV["VCAP_SERVICES"] || "{}")
+                 .dig("elasticsearch", 0, "credentials", "uri") %>'

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,64 +1,13 @@
-require 'base64'
-
-def create_es_cert_file(cert)
-  begin
-    es_cert_file = File.new('elasticsearch_cert.pem', 'w')
-    es_cert_file.write(cert)
-    es_cert_file.close
-  rescue StandardError => e
-    Rails.logger.fatal "Failed to write elasticsearch certificate. Exiting"
-    Rails.logger.fatal e
-    exit
-  end
-  es_cert_file
-end
-
-def es_config_from_vcap
-  begin
-    vcap = JSON.parse(Rails.configuration.elasticsearch['vcap_services'])
-    es_servers = vcap['elasticsearch'][0]['credentials']['uris'].map do |uri|
-      uri.chomp('/')
-    end
-    es_cert = Base64.decode64(vcap['elasticsearch'][0]['credentials']['ca_certificate_base64'])
-  rescue StandardError => e
-    Rails.logger.fatal "Failed to extract ES creds from VCAP_SERVICES. Exiting"
-    Rails.logger.fatal e
-    exit
-  end
-  es_cert_file = create_es_cert_file(es_cert)
-
-  {
-    host: es_servers,
-    transport_options: {
-      request: {
-        timeout: Rails.configuration.elasticsearch['elastic_timeout']
-      },
-      ssl: {
-        ca_file: es_cert_file.path
-      }
+config = {
+  host: Rails.application.config_for(:elasticsearch)["host"],
+  transport_options: {
+    request: {
+      timeout: Rails.application.config_for(:elasticsearch)['timeout']
+    },
+    ssl: {
+      verify: false
     }
   }
-end
-
-def es_config_from_host
-  {
-    host: Rails.configuration.elasticsearch['host'],
-    transport_options: {
-      request: {
-        timeout: Rails.configuration.elasticsearch['elastic_timeout']
-      }
-    }
-  }
-end
-
-
-if Rails.configuration.elasticsearch['host']
-  config = es_config_from_host
-elsif Rails.configuration.elasticsearch['vcap_services']
-  config = es_config_from_vcap
-else
-  Rails.logger.fatal "No elasticsearch environment variables found"
-  config = nil
-end
+}
 
 Elasticsearch::Model.client = Elasticsearch::Client.new(config)


### PR DESCRIPTION
https://trello.com/c/RouPcOX9/400-simplify-elastic-configuration-logic

The ES initialization logic was confusing because it was coupled to the
associated YML file. Making the YML file do more work helps to clarify
where the configuration is coming from in each environment.

It should not be necessary to verify the ES certificate in the same way
that we don't verify the identity of the Postgres DB that the app is
connecting to.