### PR TITLE
Update sprockets to 3.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)


### PR DESCRIPTION
Fixes a security vulnerability[1].

[1]: https://groups.google.com/forum/#!topic/rubyonrails-security/ft_J--l55fM