### PR TITLE
Ignore missing datasets when unpublishing

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -39,6 +39,8 @@ class Dataset < ApplicationRecord
   def unpublish
     return unless published?
     __elasticsearch__.delete_document(id: uuid)
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+    Rails.logger.warn(e)
   end
 
   def as_indexed_json(_options = {})

--- a/app/workers/ckan/v26/ckan_org_sync_worker.rb
+++ b/app/workers/ckan/v26/ckan_org_sync_worker.rb
@@ -18,11 +18,9 @@ module CKAN
       end
 
       def delete_old_organisations(organisation_ids)
-        Organisation.transaction do
-          organisations = Organisation.where(name: organisation_ids)
-          Dataset.where(organisation: organisations).each(&:unpublish)
-          organisations.destroy_all
-        end
+        organisations = Organisation.where(name: organisation_ids)
+        Dataset.where(organisation: organisations).each(&:unpublish)
+        organisations.destroy_all
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/6w4BSyGg/390-sync-a-single-organisation-to-find-using-the-ckan-api

It's possible for a dataset to be unpublished but not deleted as these
operations span multiple databases. We can safely catch a NotFound error
when unpublishing because the operation becomes a no-op; this should
only occur when a previous batch delete has failed and does not indicate
a consistency issue in general, provided the sync workers run regularly.