### PR TITLE
Ensure ES operations succeed for index/delete_doc

### DIFF
--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe Dataset do
-  let!(:org) { @org = Organisation.create!(name: "land-registry", title: "Land Registry") }
+  subject { create :dataset, organisation: (create :organisation) }
 
   it "requires a title and a summary" do
     dataset = Dataset.new(title: "", summary: "")
@@ -34,5 +34,51 @@ describe Dataset do
     dataset.update(title: "My Even Better Dataset")
 
     expect(dataset.name).to eq("my-even-better-dataset")
+  end
+
+  describe '#publish' do
+    it 'changes the dataset status to published' do
+      subject.publish
+      expect(subject.published?).to be_truthy
+    end
+
+    it 'indexes the document into Elasticsearch' do
+      subject.publish
+      expect { get_from_es(subject.uuid) }.to_not raise_error
+    end
+
+    it 'raises an error when the ES index fails' do
+      allow(subject.__elasticsearch__).to receive(:index_document)
+        .and_return("_shards" => { "failed" => 1 })
+
+      expect { subject.publish }.to raise_error(/Failed to publish/)
+      expect(subject.reload.published?).to be_falsey
+    end
+  end
+
+  describe '#unpublish' do
+    before do
+      subject.publish
+    end
+
+    it 'changes the dataset status to draft' do
+      subject.unpublish
+      expect(subject.draft?).to be_truthy
+    end
+
+    it 'deletes the document from Elasticsearch' do
+      subject.unpublish
+
+      expect { get_from_es(subject.uuid) }
+        .to raise_error(Elasticsearch::Transport::Transport::Errors::NotFound)
+    end
+
+    it 'raises an error when the ES delete fails' do
+      allow(subject.__elasticsearch__).to receive(:delete_document)
+        .and_return("_shards" => { "failed" => 1 })
+
+      expect { subject.unpublish }.to raise_error(/Failed to unpublish/)
+      expect(subject.published?).to be_truthy
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/gVCoFinx/420-investigate-sync-issues

We should ensure that we receive a 'success' response from ES when
performing operations, as it looks like these sometimes fail after
seeing discrepancies between the number of documents in the local DB and
in ES, despite there being no indexing issues when manually publishing.