### PR TITLE
Use the INSPIRE ref date for public_updated_at

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -104,11 +104,24 @@ class Dataset < ApplicationRecord
   end
 
   def public_updated_at
-    most_recently_updated_datafile_timestamp || self.updated_at
+    inspire_dataset_reference_date ||
+      most_recently_updated_datafile_timestamp ||
+      self.updated_at
   end
 
   def released
     links.count.positive?
+  end
+
+  def inspire_dataset_reference_date
+    return unless inspire_dataset
+
+    reference_date = inspire_dataset.dataset_reference_date
+    json = JSON.parse(reference_date)
+
+    json.map { |date| Date.parse(date["value"]) }.max
+  rescue ArgumentError
+    nil
   end
 
 private

--- a/spec/factories/dataset.rb
+++ b/spec/factories/dataset.rb
@@ -16,5 +16,9 @@ FactoryGirl.define do
     trait :with_doc do
       docs { create_list(:doc, 1) }
     end
+
+    trait :inspire do
+      inspire_dataset { build :inspire_dataset }
+    end
   end
 end

--- a/spec/factories/inspire_dataset.rb
+++ b/spec/factories/inspire_dataset.rb
@@ -1,4 +1,13 @@
 FactoryGirl.define do
   factory :inspire_dataset do
+    dataset_reference_date do
+      "[{\"type\": \"publication\", \"value\": \"2015-12-03\"}, {\"type\": \"revision\", \"value\": \"2015-12-03\"}, {\"type\": \"creation\", \"value\": \"2006-01-01\"}]"
+    end
+
+    trait :invalid do
+      dataset_reference_date do
+        "[{\"type\": \"revision\", \"value\": \"2016-07\"}]"
+      end
+    end
   end
 end

--- a/spec/features/ckan_v26_package_import_spec.rb
+++ b/spec/features/ckan_v26_package_import_spec.rb
@@ -60,16 +60,14 @@ describe 'ckan package import' do
     end
 
     it 'updates an inspire dataset if it already exists' do
-      create :dataset, uuid: package_inspire_id,
-                       inspire_dataset: (build :inspire_dataset)
+      create :dataset, :inspire, uuid: package_inspire_id
 
       expect { subject.perform(package_inspire_id) }
         .to_not(change { InspireDataset.count })
     end
 
     it 'removes an inspire dataset if it is not in the package' do
-      create :dataset, uuid: package_create_id,
-                       inspire_dataset: (build :inspire_dataset)
+      create :dataset, :inspire, uuid: package_create_id
 
       expect { subject.perform(package_create_id) }
         .to change { InspireDataset.count }.by(-1)

--- a/spec/features/dataset_publish_spec.rb
+++ b/spec/features/dataset_publish_spec.rb
@@ -50,4 +50,25 @@ describe "publishing datasets" do
     document = get_from_es(dataset.uuid)
     expect(document["public_updated_at"]).to eq in_es_format(dataset.reload.updated_at)
   end
+
+  it 'determines the public_updated_at for inspire datasets' do
+    dataset = create :dataset, :inspire, creator: user, organisation: land
+    visit dataset_url(dataset.uuid, dataset.name)
+    click_button 'Publish'
+
+    document = get_from_es(dataset.uuid)
+    date = JSON.parse(dataset.inspire_dataset.dataset_reference_date).first["value"]
+    expect(document["public_updated_at"]).to eq in_es_format(date)
+  end
+
+  it 'copes with invalid inspire dataset reference dates' do
+    dataset = create :dataset, inspire_dataset: (build :inspire_dataset, :invalid),
+      creator: user, organisation: land
+
+    visit dataset_url(dataset.uuid, dataset.name)
+    click_button 'Publish'
+
+    document = get_from_es(dataset.uuid)
+    expect(document["public_updated_at"]).to eq in_es_format(dataset.reload.updated_at)
+  end
 end


### PR DESCRIPTION
https://trello.com/c/vEj1dI9y/339-last-updated-field-doesnt-represent-the-real-date-that-some-data-fields-were-updated

The INSPIRE reference dates are a better indicator of recency for a
dataset, where available. If a dataset has INSPIRE metadata, we will use
the maximum of its reference dates as the dataset public_updated_at,
provided these dates are valid (day, month, year).

From user examples we can see that, while 'revision' is commonly the
right reference date to use, sometimes this is not available but another
reference field like 'published' can serve as a suitable indiactor of
recency; to avoid complex logic, we'll start by maxing over them all.