### PR TITLE
Fix UUID for GDS Org to match CKAN

### DIFF
--- a/db/migrate/20180502153341_map_gds_content_id_from_govuk.rb
+++ b/db/migrate/20180502153341_map_gds_content_id_from_govuk.rb
@@ -1,8 +1,9 @@
 class MapGdsContentIdFromGovuk < ActiveRecord::Migration[5.1]
   def change
-    org = Organisation.find_or_create_by(uuid: 'af07d5a5-df63-4ddc-9383-6a666845ebe9',
-                                         name: 'government-digital-services')
+    org = Organisation.find_or_create_by(uuid: '90aefa0d-0e92-4895-a7fd-c1adb2b3f14f',
+                                         name: 'government-digital-service')
 
     org.update_attribute(:govuk_content_id, 'af07d5a5-df63-4ddc-9383-6a666845ebe9')
+    org.update_attribute(:title, 'Government Digital Service')
   end
 end


### PR DESCRIPTION
https://trello.com/c/VvaTibq9/435-fix-publish-migrations-out-of-order

For some reason the original name/UUID for GDS was incorrect.