### PR TITLE
Do not bind GDS prometheus to the PaaS app

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -12,4 +12,3 @@ applications:
   - publish-beta-production-redis
   - publish-production-secrets
   - logit-ssl-drain
-  - dgu-prometheus

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -12,4 +12,3 @@ applications:
   - publish-beta-staging-redis
   - logit-ssl-drain
   - beta-staging-elasticsearch
-  - dgu-prometheus


### PR DESCRIPTION
This application no longer requires metric collection by the
GDS prometheus, as implemented by
https://github.com/alphagov/datagovuk_publish/pull/684

This commit removes the PaaS service bind so that Prometheus
will not try and collect metrics as intended.