### PR TITLE
Switch to new elasticsearch

### DIFF
--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,48 +1,20 @@
-require 'base64'
-
-def create_es_cert_file(cert)
-  begin
-    es_cert_file = File.new('elasticsearch_cert.pem', 'w')
-    es_cert_file.write(cert)
-    es_cert_file.close
-  rescue StandardError => e
-    Rails.logger.fatal "Failed to write elasticsearch certificate. Exiting"
-    Rails.logger.fatal e
-    exit
-  end
-  es_cert_file
-end
-
 def es_config_from_vcap
   begin
     vcap = JSON.parse(Rails.configuration.elasticsearch['vcap_services'])
-    es_servers = vcap['elasticsearch'][0]['credentials']['uris'].map do |uri|
-      uri.chomp('/')
-    end
-    es_cert = Base64.decode64(vcap['elasticsearch'][0]['credentials']['ca_certificate_base64'])
+    es_server = vcap['elasticsearch'][0]['credentials']['uri']
   rescue StandardError => e
     Rails.logger.fatal "Failed to extract ES creds from VCAP_SERVICES. Exiting"
+    Rails.logger.fatal Rails.configuration.elasticsearch['vcap_services']
     Rails.logger.fatal e
     exit
   end
-  es_cert_file = create_es_cert_file(es_cert)
 
-  {
-    host: es_servers,
-    transport_options: {
-      request: {
-        timeout: Rails.configuration.elasticsearch['elastic_timeout']
-      },
-      ssl: {
-        ca_file: es_cert_file.path
-      }
-    }
-  }
+  es_config_from_host(es_server)
 end
 
-def es_config_from_host
+def es_config_from_host(host)
   {
-    host: Rails.configuration.elasticsearch['host'],
+    host: host,
     transport_options: {
       request: {
         timeout: Rails.configuration.elasticsearch['elastic_timeout']
@@ -53,7 +25,7 @@ end
 
 
 if Rails.configuration.elasticsearch['host']
-  config = es_config_from_host
+  config = es_config_from_host(Rails.configuration.elasticsearch['host'])
 elsif Rails.configuration.elasticsearch['vcap_services']
   config = es_config_from_vcap
 else

--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -7,7 +7,7 @@ applications:
     RAILS_ENV: production
     RACK_ENV: production
   services:
-  - beta-production-elasticsearch
+  - elasticsearch-beta-production
   - publish-beta-production-pg
   - publish-beta-production-redis
   - publish-production-secrets

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -7,7 +7,7 @@ applications:
     RAILS_ENV: production
     RACK_ENV: production
   services:
-  - beta-production-elasticsearch
+  - elasticsearch-beta-production
   - publish-beta-production-pg
   - publish-beta-production-redis
   - publish-production-secrets

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -11,4 +11,4 @@ applications:
   - publish-beta-staging-pg
   - publish-beta-staging-redis
   - logit-ssl-drain
-  - beta-staging-elasticsearch
+  - elasticsearch-beta-staging

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -11,5 +11,5 @@ applications:
   - publish-beta-staging-pg
   - publish-beta-staging-redis
   - logit-ssl-drain
-  - beta-staging-elasticsearch
+  - elasticsearch-beta-staging
   health-check-type: process


### PR DESCRIPTION
The PaaS is switching from IBM Compose to Aiven.  There are some changes to the configuration format, so this isn't just a straight change to the manifest.

---

The change has already been applied to the running DGU instances.  In addition to this PR, there was some devopsing around creating the new backing service (hence the new names) and reindexing everything.

---

[Trello card](https://trello.com/c/uQVcQkJ0/364-move-dgu-paas-elasticsearch)