### PR TITLE
Always update records that are returned by CKAN but marked as draft locally

### DIFF
--- a/app/services/ckan/v26/package_differ.rb
+++ b/app/services/ckan/v26/package_differ.rb
@@ -29,11 +29,12 @@ module CKAN
       end
 
       def diff_update(packages, datasets)
-        datasets = Hash[datasets.pluck(:uuid, :updated_at)]
+        datasets_modified = Hash[datasets.pluck(:uuid, :updated_at)]
+        datasets_status = Hash[datasets.pluck(:uuid, :status)]
 
         packages.to_a.select do |package|
-          updated_at = datasets[package.get("id")]
-          updated_at && package_is_changed?(package, updated_at)
+          updated_at = datasets_modified[package.get("id")]
+          (updated_at && package_is_changed?(package, updated_at)) || datasets_status[package.get("id")] == 'draft'
         end
       end
 

--- a/app/workers/ckan/v26/package_sync_worker.rb
+++ b/app/workers/ckan/v26/package_sync_worker.rb
@@ -28,6 +28,10 @@ module CKAN
       def delete_old_datasets(datasets)
         datasets.each(&:unpublish)
         datasets.destroy_all
+        if datasets.length > 100
+          msg = "More than 100 datasets have been unpublished in a single sync run.  This suggests a problem with the response from CKAN."
+          Raven.capture msg
+        end
       end
     end
   end

--- a/spec/features/ckan_v26_package_sync_spec.rb
+++ b/spec/features/ckan_v26_package_sync_spec.rb
@@ -13,6 +13,8 @@ describe 'ckan package sync' do
   let(:dataset_to_create_id) { search_dataset_p1["results"][2]["id"] }
 
   let!(:dataset_to_delete) { create :dataset, legacy_name: "dataset_to_delete" }
+  let!(:dataset_to_republish_draft) { create :dataset, uuid: "fa37dff7-bbc0-4a84-a146-7eee332c9c1f", status: "draft" }
+  let!(:dataset_to_republish) { create :dataset, uuid: "fa37dff7-bbc0-4a84-a146-7eee332c9c1f" }
   let!(:dataset_to_ignore) { create :dataset, legacy_name: nil }
 
   let!(:dataset_to_update) do
@@ -75,5 +77,12 @@ describe 'ckan package sync' do
 
     expect(Dataset.all).to_not include dataset_to_delete
     expect { get_from_es(dataset_to_delete.uuid) }.to raise_error(/404/)
+  end
+
+  it 'republishes draft datasets when they reappear in ckan' do
+    dataset_to_republish_draft.publish
+    subject.perform
+
+    expect(Dataset.all).to include dataset_to_republish
   end
 end


### PR DESCRIPTION
Previously, records that were marked as draft in the local Postgres database
would never get marked as published, even if they are made available again
though the CKAN API.

This updates that logic so that datasets which are returned in the CKAN API
response but are draft in the local database are always updated, thus
marking them as published again.

https://trello.com/c/smOj0SX5/408-investigate-dgu-package-deletion