### PR TITLE
Set staging ckan base url to data.gov.uk

### DIFF
--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -2,5 +2,5 @@ require_relative './production'
 
 Rails.application.configure do
   config.assets.compile = true
-  config.ckan_v26_base_url = "https://staging.data.gov.uk"
+  config.ckan_v26_base_url = "https://data.gov.uk"
 end


### PR DESCRIPTION
The CKAN staging server has been turned off. Since the staging url no
longer resolves, running staging publish on the Paas now results in
errors being thrown when the Sidkekiq workers try to sync data from the
staging CKAN. Setting this url to the live version of CKAN should stop
this error occurring. This does mean that we will be syncing the live
data to both staging and production versions hosted on the Paas.