### PR TITLE
Add instructions for running Publish on a Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,70 @@ You will need to install the following for development.
 
 Most of these can be installed with Homebrew on a Mac.
 
-## Getting Started
+## Developing on a Mac with a local CKAN installation
 
-Run the following commands to get started.
+Install all the requirements for this app using Homebrew:
 
 ```
-# install dependencies
-bin/setup
+## PostgreSQL
+brew install postgresql
 
-# start a web server
+## Redis
+brew install redis
+
+## Elasticsearch
+brew tap caskroom/versions
+brew cask install java8
+brew install elasticsearch
+```
+
+Start the services on your machine:
+
+```
+brew services start postgresql
+brew services start elasticsearch
+brew services start redis
+```
+
+Configure the base URL of your local CKAN in `./config/environments/development.rb`:
+
+```
+config.ckan_v26_base_url = "http://localhost:4000"
+```
+
+Install dependencies, initialise the database and search index:
+
+```
+bin/setup
+```
+
+Start the web server:
+
+```
 rails s
 ```
 
 Then navigate to `http://localhost:3000`.
+
+To sync data from CKAN, set up the workers, then run Sidekiq to process the queue:
+
+```
+bin/rails runner CKAN::V26::CKANOrgSyncWorker.new.perform
+bin/rails runner CKAN::V26::PackageSyncWorker.new.perform
+bundle exec sidekiq
+```
+
+To completely clear the database, execute the following:
+
+```
+bin/rails db:drop db:setup
+```
+
+To re-index Elasticsearch based on the current database contents, run:
+
+```
+bin/rails search:reindex
+```
 
 ## Documentation
 


### PR DESCRIPTION
These instructions explain how GOV.UK developers can run Publish (including the sync) on their local machine