### PR TITLE
Update Publish to reflect changes to new CKAN API

### DIFF
--- a/app/models/ckan/v26/package.rb
+++ b/app/models/ckan/v26/package.rb
@@ -14,6 +14,11 @@ module CKAN
         @extras[key]
       end
 
+      def get_harvest(key)
+        @harvest ||= hashify(@package["harvest"] || [])
+        @harvest[key]
+      end
+
       def resources
         @package["resources"].map { |resource| Resource.new(resource) }
       end

--- a/app/services/ckan/v26/dataset_mapper.rb
+++ b/app/services/ckan/v26/dataset_mapper.rb
@@ -42,7 +42,7 @@ module CKAN
       end
 
       def harvested?(package)
-        package.get_extra("harvest_object_id").present?
+        package.get_extra("harvest_object_id").present? || package.get_harvest("harvest_object_id").present?
       end
 
       def build_location(package)

--- a/app/services/ckan/v26/dataset_mapper.rb
+++ b/app/services/ckan/v26/dataset_mapper.rb
@@ -21,7 +21,7 @@ module CKAN
           licence_url: Licence.lookup(package.get("license_id")).url,
           licence_custom: package.get_extra("licence"),
           topic_id: lookup_topic(package),
-          schema_id: package.get("schema")&.first&.fetch("id"),
+          schema_id: package.get("schema")&.first&.fetch("id") || package.get("schema-vocabulary"),
           status: "published",
         }
       end

--- a/app/services/ckan/v26/inspire_mapper.rb
+++ b/app/services/ckan/v26/inspire_mapper.rb
@@ -11,7 +11,7 @@ module CKAN
           coupled_resource: package.get_extra('coupled-resource'),
           dataset_reference_date: package.get_extra('dataset-reference-date'),
           frequency_of_update: package.get_extra('frequency-of-update'),
-          harvest_object_id: package.get_extra('harvest_object_id'),
+          harvest_object_id: package.get_extra('harvest_object_id') || package.get_harvest('harvest_object_id'),
           harvest_source_reference: package.get_extra('harvest_source_reference'),
           import_source: package.get_extra('import_source'),
           metadata_date: package.get_extra('metadata-date'),


### PR DESCRIPTION
The new CKAN instance has some slight changes to the API schema.  These commits allow the `harvest_object_id`, `harvested` and `schema_id` values to be populated using the new schema.  Backwards compatibility is maintained to ensure the Publish sync process can read from both the old and new APIs.

Trello card: https://trello.com/c/WFsQ1AcV/65-update-publish-to-use-new-harvestobjectid-and-schema-vocabulary