### PR TITLE
Only count deletions against the number of published documents

### DIFF
--- a/app/services/ckan/v26/package_differ.rb
+++ b/app/services/ckan/v26/package_differ.rb
@@ -8,7 +8,7 @@ module CKAN
       def call
         datasets = Dataset.where.not(legacy_name: nil)
 
-        packages = client.search_dataset(fl: CKAN_FIELDS, existing_total: datasets.size)
+        packages = client.search_dataset(fl: CKAN_FIELDS, existing_total: datasets.published.size)
           .map { |response| Package.new(response) }
 
         {


### PR DESCRIPTION
There have been a large number of CKAN::V26::Depaginator::DeletionTooLargeError exceptions recently.  This is preventing the sync from CKAN to Publish from running correctly.  This was happening because we were comparing the total number of datasets against the new number of datasets, rather than just comparing the published datasets against the new number of datasets.