### PR TITLE
Ignore datasets that have already been deleted from the index

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -41,7 +41,7 @@ class Dataset < ApplicationRecord
 
   def unpublish
     return unless published?
-    result = __elasticsearch__.delete_document(id: uuid)
+    result = __elasticsearch__.delete_document(id: uuid, ignore: 404)
 
     raise "Failed to unpublish" if result["_shards"]["failed"].positive?
     draft!


### PR DESCRIPTION
If a dataset has already been removed from the index (e.g. by a concurrent worker), `delete_document` will return a 404 error.  This has resulted in a large number of errors being sent to Sentry.  Adding `ignore: 404` will stop this error where the dataset has already been deleted.

Trello card: https://trello.com/c/5GaHfYts/107-how-might-we-send-fewer-errors-to-sentry-from-publish