### PR TITLE
[REQUIRES REINDEX] Revamp the way we calculate public_updated_at

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -104,9 +104,11 @@ class Dataset < ApplicationRecord
   end
 
   def public_updated_at
-    inspire_dataset_reference_date ||
-      most_recently_updated_datafile_timestamp ||
-      self.updated_at
+    timestamps = [inspire_dataset_reference_date,
+                  most_recently_updated_datafile_timestamp].compact
+
+    return self.updated_at if timestamps.none?
+    timestamps.max
   end
 
   def released

--- a/spec/features/dataset_publish_spec.rb
+++ b/spec/features/dataset_publish_spec.rb
@@ -61,6 +61,23 @@ describe "publishing datasets" do
     expect(document["public_updated_at"]).to eq in_es_format(date)
   end
 
+  it 'determines the public_updated_at with datafiles' do
+    visit dataset_url(dataset.uuid, dataset.name)
+    click_button 'Publish'
+
+    document = get_from_es(dataset.uuid)
+    expect(document["public_updated_at"]).to eq in_es_format(dataset.datafiles.first.updated_at)
+  end
+
+  it 'determines the public_updated_at for inspire datasets with datafiles' do
+    dataset = create :dataset, :with_datafile, :inspire, creator: user, organisation: land
+    visit dataset_url(dataset.uuid, dataset.name)
+    click_button 'Publish'
+
+    document = get_from_es(dataset.uuid)
+    expect(document["public_updated_at"]).to eq in_es_format(dataset.datafiles.first.updated_at)
+  end
+
   it 'copes with invalid inspire dataset reference dates' do
     dataset = create :dataset, inspire_dataset: (build :inspire_dataset, :invalid),
       creator: user, organisation: land


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/3539916

Previously we calculated the public_updated_at field for a dataset based
on the first available timestamp in the list of things to try. This
changes the way we calculate this field as part of the publish payload,
so that we try to get the latest timestamp out of the ones available.