### PR TITLE
Update path for CKAN dataset search endpoint

### DIFF
--- a/lib/ckan/v26/client.rb
+++ b/lib/ckan/v26/client.rb
@@ -27,7 +27,7 @@ module CKAN
       end
 
       def search_dataset(fl:, existing_total:)
-        url = build_url(path: SEARCH_DATASET_PATH, params: { rows: 1000, fl: fl.join(",") })
+        url = build_url(path: SEARCH_DATASET_PATH, params: { q: 'type:dataset', rows: 1000, fl: fl.join(",") })
         Depaginator.depaginate(url, existing_total: existing_total)
       end
 


### PR DESCRIPTION
Previously CKAN returned only datasets.  Now it returns packages (datasets and harvesters).  This filters that back down to datasets only.