### PR TITLE
Update services to use elasticsearch 6 service

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -8,8 +8,8 @@ applications:
     RAILS_ENV: production
     RACK_ENV: production
   services:
-  - elasticsearch-beta-production
+  - publish-production-secrets
   - publish-beta-production-pg
   - publish-beta-production-redis
-  - publish-production-secrets
   - logit-ssl-drain
+  - elasticsearch-6-beta-production

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -8,9 +8,9 @@ applications:
     RAILS_ENV: production
     RACK_ENV: production
   services:
-  - elasticsearch-beta-production
+  - publish-production-secrets
   - publish-beta-production-pg
   - publish-beta-production-redis
-  - publish-production-secrets
   - logit-ssl-drain
+  - elasticsearch-6-beta-production
   health-check-type: process

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -12,4 +12,4 @@ applications:
   - publish-beta-staging-pg
   - publish-beta-staging-redis
   - logit-ssl-drain
-  - elasticsearch-beta-staging
+  - elasticsearch-6-beta-staging

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -12,5 +12,5 @@ applications:
   - publish-beta-staging-pg
   - publish-beta-staging-redis
   - logit-ssl-drain
-  - elasticsearch-beta-staging
+  - elasticsearch-6-beta-staging
   health-check-type: process


### PR DESCRIPTION
## What 

As ES 5 will no longer be supported, a new ES 6 service has been deployed to replace it.

This PR also contains code updates to reorder production services like staging to make it easier to maintain the manifests