### PR TITLE
Add healthcheck for CKANOrgSyncWorker

### DIFF
--- a/app/models/healthcheck/recurring_jobs/ckan_org_sync.rb
+++ b/app/models/healthcheck/recurring_jobs/ckan_org_sync.rb
@@ -1,0 +1,51 @@
+module Healthcheck
+  module RecurringJobs
+    class CKANOrgSync
+      include ActionView::Helpers::DateHelper
+
+      JOB_NAME = 'ckan_v26_ckan_org_sync'.freeze
+      JOB_FREQUENCY = 24.hours
+      WARNING_DELAY = 3.hours # After 11 retries
+      CRITICAL_DELAY = 6.hours # After 13 retries and Sidekiq stops retrying
+
+      def name
+        :CKAN_org_sync
+      end
+
+      def status
+        if Time.parse(when_last_run) <= critical_latency
+          :critical
+        elsif Time.parse(when_last_run) <= warning_latency
+          :warning
+        else
+          :ok
+        end
+      end
+
+      def details
+        {
+          critical: when_last_run,
+          warning: when_last_run
+        }
+      end
+
+      def message
+        "The job '#{JOB_NAME}' should run every #{distance_of_time_in_words(JOB_FREQUENCY)}. It was last run #{when_last_run}."
+      end
+
+    private
+
+      def when_last_run
+        SidekiqScheduler::RedisManager.get_job_last_time(JOB_NAME)
+      end
+
+      def critical_latency
+        (JOB_FREQUENCY + CRITICAL_DELAY).ago
+      end
+
+      def warning_latency
+        (JOB_FREQUENCY + WARNING_DELAY).ago
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,7 @@ Rails.application.routes.draw do
   resource :session, only: %i[new create]
 
   get "/healthcheck", to: GovukHealthcheck.rack_response(
-    Healthcheck::RecurringJobs::PackageSync.new
+    Healthcheck::RecurringJobs::PackageSync.new,
+    Healthcheck::RecurringJobs::CKANOrgSync.new
   )
 end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -4,52 +4,63 @@ RSpec.describe 'Healthcheck', type: :request do
   end
 
   let(:sidekiq_redis) { SidekiqScheduler::RedisManager }
-  let(:message) { "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run #{when_last_run}." }
-  let(:expected_data) do
-    {
-      status: status,
-      checks: {
-        package_sync: {
-          critical: when_last_run,
-          warning: when_last_run,
-          status: status,
-          message: message
-        }
-      }
-    }
-  end
 
-  before do
-    allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
-  end
-
-  context 'when the healthchecks pass' do
+  context "when the healthchecks pass" do
     let(:when_last_run) { String(10.minutes.ago) }
-    let(:status) { 'ok' }
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
 
     it "returns a status of 'ok'" do
-      get '/healthcheck'
-      expect(data).to eq(expected_data)
+      get "/healthcheck"
+      expect(data.fetch(:status)).to eq("ok")
     end
   end
 
-  context 'when one of the healthchecks is warning' do
+  context "when one of the healthchecks is warning" do
     let(:when_last_run) { String(12.minutes.ago) }
-    let(:status) { 'warning' }
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
 
     it "returns a status of 'warning'" do
       get '/healthcheck'
-      expect(data).to eq(expected_data)
+      expect(data.fetch(:status)).to eq('warning')
     end
   end
 
-  context 'when one of the healthchecks is critical' do
+  context "when one of the healthchecks is critical" do
     let(:when_last_run) { String(70.minutes.ago) }
-    let(:status) { 'critical' }
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
 
     it "returns a status of 'critical'" do
       get '/healthcheck'
-      expect(data).to eq(expected_data)
+      expect(data.fetch(:status)).to eq('critical')
     end
+  end
+
+  let(:when_package_sync_last_run) { String(10.minutes.ago) }
+  let(:when_ckan_org_sync_last_run) { String(24.hours.ago) }
+
+  it "includes useful information about each check" do
+    allow(sidekiq_redis).to receive(:get_job_last_time).with('ckan_v26_package_sync').and_return(when_package_sync_last_run)
+    allow(sidekiq_redis).to receive(:get_job_last_time).with('ckan_v26_ckan_org_sync').and_return(when_ckan_org_sync_last_run)
+
+    get "/healthcheck"
+
+    expect(data.fetch(:checks)).to include(
+      package_sync:  { :critical => when_package_sync_last_run,
+                       :warning => when_package_sync_last_run,
+                       :status => 'ok',
+                       :message => "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run #{when_package_sync_last_run}."
+                     },
+      CKAN_org_sync: { :critical => when_ckan_org_sync_last_run,
+                       :warning => when_ckan_org_sync_last_run,
+                       :status => 'ok',
+                       :message => "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run #{when_ckan_org_sync_last_run}."
+                     }
+    )
   end
 end

--- a/spec/integration/healthcheck_spec.rb
+++ b/spec/integration/healthcheck_spec.rb
@@ -51,16 +51,14 @@ RSpec.describe 'Healthcheck', type: :request do
     get "/healthcheck"
 
     expect(data.fetch(:checks)).to include(
-      package_sync:  { :critical => when_package_sync_last_run,
-                       :warning => when_package_sync_last_run,
-                       :status => 'ok',
-                       :message => "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run #{when_package_sync_last_run}."
-                     },
-      CKAN_org_sync: { :critical => when_ckan_org_sync_last_run,
-                       :warning => when_ckan_org_sync_last_run,
-                       :status => 'ok',
-                       :message => "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run #{when_ckan_org_sync_last_run}."
-                     }
+      package_sync:  { critical: when_package_sync_last_run,
+                       warning: when_package_sync_last_run,
+                       status: 'ok',
+                       message: "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run #{when_package_sync_last_run}." },
+      CKAN_org_sync: { critical: when_ckan_org_sync_last_run,
+                       warning: when_ckan_org_sync_last_run,
+                       status: 'ok',
+                       message: "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run #{when_ckan_org_sync_last_run}." }
     )
   end
 end

--- a/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
+++ b/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Healthcheck::RecurringJobs::CKANOrgSync do
   end
 
   describe '#details' do
-    let(:when_last_run) { String(Time.now) } # any time is ok for this test
+    let(:when_last_run) { String(Time.zone.now) } # any time is ok for this test
 
     before do
       allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
@@ -54,8 +54,8 @@ RSpec.describe Healthcheck::RecurringJobs::CKANOrgSync do
   end
 
   describe '#message' do
-    let(:when_last_run) { String(Time.new(2019, 4, 16, 1, 00)) } # any time is ok for this test
-    let(:message) { "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run 2019-04-16 01:00:00 +0100." }
+    let(:when_last_run) { String(Time.zone.local(2019, 4, 16, 1, 00)) } # any time is ok for this test
+    let(:message) { "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run 2019-04-16 01:00:00 UTC." }
 
     before do
       allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)

--- a/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
+++ b/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Healthcheck::RecurringJobs::CKANOrgSync do
   end
 
   describe '#message' do
-    let(:when_last_run) { String(Time.zone.local(2019, 4, 16, 1, 00)) } # any time is ok for this test
-    let(:message) { "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run 2019-04-16 01:00:00 UTC." }
+    let(:when_last_run) { String(Time.zone.local(2019, 4, 16, 23, 10)) } # any time is ok for this test
+    let(:message) { "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run 2019-04-16 23:10:00 UTC." }
 
     before do
       allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)

--- a/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
+++ b/spec/models/healthcheck/recurring_jobs/ckan_org_sync_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe Healthcheck::RecurringJobs::CKANOrgSync do
+  subject { described_class.new }
+  let(:sidekiq_redis) { SidekiqScheduler::RedisManager }
+
+  describe '#name' do
+    it "returns the correct job's name" do
+      expect(subject.name).to eq(:CKAN_org_sync)
+    end
+  end
+
+  describe '#status' do
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
+
+    context 'when the job was last run less than 25 hours ago' do
+      let(:when_last_run) { String(24.hours.ago) }
+
+      it 'returns status :ok' do
+        expect(subject.status).to eq(:ok)
+      end
+    end
+
+    context 'when the job was last run 24 or more hours ago' do
+      let(:when_last_run) { String(27.hours.ago) }
+
+      it 'returns status :warning' do
+        expect(subject.status).to eq(:warning)
+      end
+    end
+
+    context 'when the job was last run 41 or more hours ago' do
+      let(:when_last_run) { String(30.hours.ago) }
+
+      it 'returns status :critical' do
+        expect(subject.status).to eq(:critical)
+      end
+    end
+  end
+
+  describe '#details' do
+    let(:when_last_run) { String(Time.now) } # any time is ok for this test
+
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
+
+    it 'returns the currect values' do
+      expect(subject.details).to eq(
+        critical: when_last_run,
+        warning: when_last_run
+      )
+    end
+  end
+
+  describe '#message' do
+    let(:when_last_run) { String(Time.new(2019, 4, 16, 1, 00)) } # any time is ok for this test
+    let(:message) { "The job 'ckan_v26_ckan_org_sync' should run every 1 day. It was last run 2019-04-16 01:00:00 +0100." }
+
+    before do
+      allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
+    end
+
+    it 'returns the correct message' do
+      expect(subject.message).to eq(message)
+    end
+  end
+end

--- a/spec/models/healthcheck/recurring_jobs/package_sync_spec.rb
+++ b/spec/models/healthcheck/recurring_jobs/package_sync_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Healthcheck::RecurringJobs::PackageSync do
   end
 
   describe '#details' do
-    let(:when_last_run) { String(Time.now) } # any time is ok for this test
+    let(:when_last_run) { String(Time.zone.now) } # any time is ok for this test
 
     before do
       allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)
@@ -54,8 +54,8 @@ RSpec.describe Healthcheck::RecurringJobs::PackageSync do
   end
 
   describe '#message' do
-    let(:when_last_run) { String(Time.new(1984, 1, 16, 23, 10)) } # any time is ok for this test
-    let(:message) { "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run 1984-01-16 23:10:00 +0000." }
+    let(:when_last_run) { String(Time.zone.local(1984, 1, 16, 23, 10)) } # any time is ok for this test
+    let(:message) { "The job 'ckan_v26_package_sync' should run every 10 minutes. It was last run 1984-01-16 23:10:00 UTC." }
 
     before do
       allow(sidekiq_redis).to receive(:get_job_last_time).and_return(when_last_run)


### PR DESCRIPTION
The CKANOrgSyncWorker is a recurring job that runs once every 24
hours. We currently don't have any alerts in place to monitor it's
running successfully.

The `WARNING_DELAY` and `CRITICAL_DELAY` has been set based 
on it's [Sidekiq retry number](https://github.com/alphagov/datagovuk_publish/blob/master/app/workers/ckan/v26/ckan_org_sync_worker.rb#L5) and by referring to the automatic job retry table
in the [wiki](https://github.com/mperham/sidekiq/wiki/Error-Handling#automatic-job-retry)

Trello card: https://trello.com/c/ba8SOqEM/960-add-an-icinga-alert-to-notify-us-if-any-of-the-scheduled-dgu-sync-jobs-are-disabled