### PR TITLE
Fix organogram filenames

### DIFF
--- a/lib/tasks/fix_existing_organogram_filenames.rake
+++ b/lib/tasks/fix_existing_organogram_filenames.rake
@@ -1,0 +1,6 @@
+require_relative 'update_organogram_filenames.rb'
+
+desc "Fix existing organogram filenames"
+task :fix_existing_organogram_filenames => :environment do
+  UpdateOrganogramFilenames.new().call
+end

--- a/lib/tasks/fix_existing_organogram_filenames.rake
+++ b/lib/tasks/fix_existing_organogram_filenames.rake
@@ -1,6 +1,6 @@
 require_relative 'update_organogram_filenames.rb'
 
 desc "Fix existing organogram filenames"
-task :fix_existing_organogram_filenames => :environment do
-  UpdateOrganogramFilenames.new().call
+task "fix_existing_organogram_filenames" => :environment do
+  UpdateOrganogramFilenames.new.call
 end

--- a/lib/tasks/update_organogram_filenames.rb
+++ b/lib/tasks/update_organogram_filenames.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class UpdateOrganogramFilenames
   def initialize
     @old_urls = []
@@ -14,12 +16,9 @@ class UpdateOrganogramFilenames
 
   def parse_csv(csv_file)
     puts "Parsing CSV '#{csv_file}'"
-    File.open(csv_file).readlines.each do |line|
-      urls = line.split(', ')
-      urls.last.delete! "\n"
-
-      @old_urls << urls.first
-      @new_urls << urls.last
+    CSV.foreach(csv_file) do |row|
+      @old_urls << row.first
+      @new_urls << row.last.strip
     end
   end
 

--- a/lib/tasks/update_organogram_filenames.rb
+++ b/lib/tasks/update_organogram_filenames.rb
@@ -8,9 +8,8 @@ class UpdateOrganogramFilenames
     csv_file = "./lib/tasks/old_new_urls.csv"
 
     parse_csv(csv_file)
-    msg = replace_urls()
+    msg = replace_urls
     puts msg
-
   end
 
   def parse_csv(csv_file)
@@ -37,7 +36,7 @@ class UpdateOrganogramFilenames
             puts "From dataset: " + link.dataset.name
             puts "Replace url '" + link.url + "' with '" + @new_urls[index] + "'"
             link.url = @new_urls[index]
-            link.save(validate:false)
+            link.save(validate: false)
 
             if Link.where(url: @new_urls[index]).empty?
               puts "Url replacement failed"

--- a/lib/tasks/update_organogram_filenames.rb
+++ b/lib/tasks/update_organogram_filenames.rb
@@ -8,7 +8,8 @@ class UpdateOrganogramFilenames
     csv_file = "./lib/tasks/old_new_urls.csv"
 
     parse_csv(csv_file)
-    replace_urls()
+    msg = replace_urls()
+    puts msg
 
   end
 
@@ -27,25 +28,29 @@ class UpdateOrganogramFilenames
     puts "Searching for urls containing '-posts-'..."
 
     if @old_urls.empty?
-      abort "No urls to process"
+      "No urls to process"
     else
       Link.all.each do |link|
         if link.url.include? "-posts-"
           index = @old_urls.index(link.url)
+          if index != nil
+            puts "From dataset: " + link.dataset.name
+            puts "Replace url '" + link.url + "' with '" + @new_urls[index] + "'"
+            link.url = @new_urls[index]
+            link.save(validate:false)
 
-          puts "From dataset: " + link.dataset.name
-          puts "Replace url '" + link.url + "' with '" + @new_urls[index] + "'"
-          link.url = @new_urls[index]
-          link.save(validate:false)
-
-          if Link.where(url: @new_urls[index]).empty?
-            puts "Url replacement failed"
+            if Link.where(url: @new_urls[index]).empty?
+              puts "Url replacement failed"
+            else
+              puts "Url successfully replaced"
+            end
           else
-            puts "Url successfully replaced"
+            puts "WARNING: " + link.url + " not found"
           end
           puts "==============="
         end
       end
+      "Update complete"
     end
   end
 end

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -9,9 +9,11 @@ describe UpdateOrganogramFilenames do
   end
 
   context "when parsing a CSV file" do
-    it "should return an array if it contains data" do
+    it "should set old_urls and new_urls array if it contains data" do
       update_organogram_filenames = UpdateOrganogramFilenames.new
-      expect(update_organogram_filenames.parse_csv("sample_urls.csv")).to be_an_instance_of(Array)
+      update_organogram_filenames.parse_csv("sample_urls.csv")
+      expect(update_organogram_filenames.instance_eval { @old_urls }.length).to be(2)
+      expect(update_organogram_filenames.instance_eval { @new_urls }.length).to be(2)
     end
 
     it "should abort and return a message if it's empty" do

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -3,20 +3,20 @@ require_relative '../../../lib/tasks/update_organogram_filenames.rb'
 
 describe UpdateOrganogramFilenames do
   before do
-    @link1 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv"})
-    @link2 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv"})
+    @link1 = FactoryBot.create(:link, url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv")
+    @link2 = FactoryBot.create(:link, url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv")
     File.write("sample_urls.csv", "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\nhttps://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
   end
 
   context "when parsing a CSV file" do
     it "should return an array if it contains data" do
-      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      update_organogram_filenames = UpdateOrganogramFilenames.new
       expect(update_organogram_filenames.parse_csv("sample_urls.csv")).to be_an_instance_of(Array)
     end
 
     it "should abort and return a message if it's empty" do
       File.write("sample_urls.csv", "")
-      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      update_organogram_filenames = UpdateOrganogramFilenames.new
       update_organogram_filenames.parse_csv("sample_urls.csv")
       expect(update_organogram_filenames.replace_urls).to eql("No urls to process")
     end
@@ -24,7 +24,7 @@ describe UpdateOrganogramFilenames do
 
   context "when a url containing '-posts-' is found" do
     it "replaces the url with the correct url" do
-      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      update_organogram_filenames = UpdateOrganogramFilenames.new
       update_organogram_filenames.parse_csv("sample_urls.csv")
 
       update_organogram_filenames.replace_urls

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+require_relative '../../../lib/tasks/update_organogram_filenames.rb'
+# require "rake"
+
+describe UpdateOrganogramFilenames do
+  before do
+    @link1 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv"})
+    @link2 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-26Z.csv"})
+    File.write("sample_urls.csv", "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\n,https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
+  end
+
+  context "when parsing a CSV file" do
+    it "should return an array if it contains data" do
+      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      expect(update_organogram_filenames.parse_csv("sample_urls.csv")).to be_an_instance_of(Array)
+    end
+
+    it "should abort and return a message if it's empty" do
+      File.write("sample_urls.csv", "")
+      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      update_organogram_filenames.parse_csv("sample_urls.csv")
+      expect(update_organogram_filenames.replace_urls).to_return "No urls to process"
+    end
+  end
+
+  context "when a url containing '-posts-' is found" do
+    it "replaces the url with the correct url" do
+      update_organogram_filenames = UpdateOrganogramFilenames.new()
+      update_organogram_filenames.parse_csv("sample_urls.csv")
+
+      update_organogram_filenames.replace_urls
+
+      expect(Link.first.url).to eql("https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
+
+    end
+  end
+end

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -1,12 +1,11 @@
 require 'rails_helper'
 require_relative '../../../lib/tasks/update_organogram_filenames.rb'
-# require "rake"
 
 describe UpdateOrganogramFilenames do
   before do
     @link1 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv"})
-    @link2 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-26Z.csv"})
-    File.write("sample_urls.csv", "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\n,https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
+    @link2 = FactoryBot.create(:link, { url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv"})
+    File.write("sample_urls.csv", "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\nhttps://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
   end
 
   context "when parsing a CSV file" do
@@ -19,7 +18,7 @@ describe UpdateOrganogramFilenames do
       File.write("sample_urls.csv", "")
       update_organogram_filenames = UpdateOrganogramFilenames.new()
       update_organogram_filenames.parse_csv("sample_urls.csv")
-      expect(update_organogram_filenames.replace_urls).to_return "No urls to process"
+      expect(update_organogram_filenames.replace_urls).to eql("No urls to process")
     end
   end
 
@@ -30,8 +29,8 @@ describe UpdateOrganogramFilenames do
 
       update_organogram_filenames.replace_urls
 
-      expect(Link.first.url).to eql("https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
-
+      expect(Link.all[0].url).to eql("https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
+      expect(Link.all[1].url).to eql("https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
     end
   end
 end


### PR DESCRIPTION
## What

It seems like changes to the ckan database and solr index are not picked up by Publish automatically, so in order to force it to pick up the filename fixes in this card - https://trello.com/c/5KrmZ1tb/1025-fix-bug-to-show-visualisation-on-junior-post-organograms, we need to run a one-off script to update the filenames in the Publish DB, then we just reindex elasticsearch and the filenames should be updated.

The input to the process was generated by a run of this script on the appropriate environment - 

https://github.com/alphagov/ckanext-datagovuk/blob/master/bin/python_scripts/fix_organograms_s3_filenames.py
