### PR TITLE
Add a filter to the links to process in the script

### DIFF
--- a/lib/tasks/update_organogram_filenames.rb
+++ b/lib/tasks/update_organogram_filenames.rb
@@ -28,7 +28,7 @@ class UpdateOrganogramFilenames
     if @old_urls.empty?
       "No urls to process"
     else
-      Link.all.each do |link|
+      Link.where("url LIKE 'https://s3-eu-west-1.amazonaws.com%'").each do |link|
         if link.url.include? "-posts-"
           index = @old_urls.index(link.url)
           if index != nil

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -3,9 +3,9 @@ require_relative '../../../lib/tasks/update_organogram_filenames.rb'
 
 describe UpdateOrganogramFilenames do
   before do
-    @link1 = FactoryBot.create(:link, url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv")
-    @link2 = FactoryBot.create(:link, url: "https://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv")
-    File.write("sample_urls.csv", "https://amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\nhttps://amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv, https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
+    FactoryBot.create(:link, url: "https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv")
+    FactoryBot.create(:link, url: "https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv")
+    File.write("sample_urls.csv", "https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/organogram-senior-posts-2019-06-06T11-18-26Z.csv, https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv\nhttps://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/organogram-junior-posts-2019-06-06T11-18-30Z.csv, https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
   end
 
   context "when parsing a CSV file" do
@@ -31,8 +31,8 @@ describe UpdateOrganogramFilenames do
 
       update_organogram_filenames.replace_urls
 
-      expect(Link.all[0].url).to eql("https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
-      expect(Link.all[1].url).to eql("https://amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
+      expect(Link.all[0].url).to eql("https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
+      expect(Link.all[1].url).to eql("https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
     end
   end
 end


### PR DESCRIPTION
This improvement means we are only searching for specific links,
rather than looping through all of them. We discovered this when
testing on staging where it caused a memory issue on the VM and
the task gets killed.

Trello card: https://trello.com/c/5KrmZ1tb/1025-fix-bug-to-show-visualisation-on-junior-post-organograms