### PR TITLE
Ignore 404 errors in non-production environments

### DIFF
--- a/app/workers/ckan/v26/package_import_worker.rb
+++ b/app/workers/ckan/v26/package_import_worker.rb
@@ -10,6 +10,8 @@ module CKAN
         package = get_package_from_ckan(package_id)
         dataset = Dataset.find_or_initialize_by(uuid: package_id)
         update_dataset_from_package(package, dataset)
+      rescue OpenURI::HTTPError
+        raise if Rails.env.production?
       end
 
     private


### PR DESCRIPTION
In staging, the CKAN postgres database is synced from production every day. When this was set up we made a decision to not sync Solr because it's a new technology on GOV.UK, it takes 3 days to reindex and it would involve writing custom sync code for Solr.

When accessing the CKAN API the `/api/3/search/dataset` endpoint is backed by the data in Solr which means that it returns results for datasets which have subsequently been removed (during the data sync process if the dataset is removed in production). The import worker then tries to access more information about those datasets but that endpoint (which is now backed by Postgres) returns a 404 error.

In production this tells us about a real problem in our system (Solr is out of sync with Postgres) but in staging it's not very useful, and is filling up our Sentry quota.

This is a quick solution to the problem we have of Sentry rate limiting us, but in the future we should look at syncing Solr properly to staging.

[Trello Card](https://trello.com/c/jJ5QJ4fV/1081-investigate-openurihttperror-in-datagovukpublish)