### PR TITLE
Set MAX_DELETIONS limit to 100

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 1500
+      MAX_DELETIONS = 100
 
       def self.depaginate(*args)
         self.new(*args).depaginate


### PR DESCRIPTION
The limit was raised to 1500 in order to remove duplicate datasets, but now that they have been removed its a good idea to restore the original value as a fail safe.