### PR TITLE
Increase app memory on staging and production

### DIFF
--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-production
   command: bundle exec rake db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
-  memory: 512M
+  memory: 1G
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   stack: cflinuxfs3
   env:

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-staging
   command: bundle exec rake db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
-  memory: 512M
+  memory: 1G
   buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
   stack: cflinuxfs3
   env:


### PR DESCRIPTION
Similar to https://github.com/alphagov/datagovuk_publish/pull/641/commits
we have been experiencing crashing package sync jobs which turned out
to be due to memory limits throughout the PackageDiffer process.

A longer term fix may be to batch this process.