### PR TITLE
Replace govuk-lint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+
 AllCops:
   TargetRubyVersion: 2.5
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -38,12 +38,12 @@ group :development, :test do
   gem "byebug", "~> 11"
   gem "dotenv-rails", "~> 2.7"
   gem "factory_bot_rails", "~> 5.1"
-  gem "govuk-lint", "~> 4.2"
   gem "pry", "~> 0.12"
   gem "pry-byebug", "~> 3.7"
   gem "pry-stack_explorer", "~> 0.4.9"
   gem "rspec", "~> 3.9"
   gem "rspec-rails", "~> 3.9"
+  gem "rubocop-govuk"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,11 +138,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -345,6 +340,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -372,8 +371,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     sentry-raven (2.11.3)
       faraday (>= 0.7.6, < 1.0)
     sidekiq (5.2.7)
@@ -466,7 +463,6 @@ DEPENDENCIES
   elasticsearch-rails (~> 6.0.0)
   factory_bot_rails (~> 5.1)
   gds-sso
-  govuk-lint (~> 4.2)
   govuk_app_config (~> 2.0.1)
   govuk_elements_rails
   govuk_sidekiq (~> 3.0)
@@ -489,6 +485,7 @@ DEPENDENCIES
   rest-client (~> 2.1.0)
   rspec (~> 3.9)
   rspec-rails (~> 3.9)
+  rubocop-govuk
   rubyzip (~> 2.0)
   sass-rails (~> 6.0)
   sentry-raven

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint"
+desc "Run rubocop"
 task "lint" do
-  sh "govuk-lint-ruby --format clang app lib spec test Gemfile"
+  sh "rubocop --format clang app lib spec test Gemfile"
 end


### PR DESCRIPTION
- The GOV.UK Lint gem is deprecated in favour of using Rubocop directly
  with a set of shared configs.
- See https://github.com/alphagov/govuk-rfcs/pull/ 100 for more context.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk