### PR TITLE
Revert "Set MAX_DELETIONS limit to 100"

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 100
+      MAX_DELETIONS = 1500
 
       def self.depaginate(*args)
         self.new(*args).depaginate


### PR DESCRIPTION
Reverts alphagov/datagovuk_publish#805

Temporarily raise MAX DELETIONS to remove back log that is currently raising lots of errors:
https://sentry.io/organizations/govuk/issues/1398589208/?project=275566&query=is%3Aunresolved