### PR TITLE
Remove style variables

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -53,4 +53,3 @@ $alpine-fresh: #128400;
 @import 'elements/components';
 
 @import 'govuk-overrides';
-@import 'components';

--- a/app/assets/stylesheets/components.scss
+++ b/app/assets/stylesheets/components.scss
@@ -3,9 +3,6 @@
 
 @mixin actions {
   text-align: right;
-  a:visited {
-    color: $link-colour;
-  }
 }
 
 
@@ -38,9 +35,6 @@
     padding-left: .3em;
     padding-right: .3em
   }
-  tbody tr:hover {
-    background-color: $panel-colour;
-  }
   &__actions {
     @include actions;
     width: 8em;
@@ -53,7 +47,6 @@
 // == show-all =================================================================
 
 .dgu-show-all__toggle {
-  color: $link-colour;
   cursor: pointer;
 }
 
@@ -69,10 +62,8 @@
     }
   }
   &__button-add, &__button-del {
-    background: $page-colour;
     border: none;
     padding: 0;
-    color: $link-colour;
     cursor: pointer;
     text-decoration: underline;
   }
@@ -93,9 +84,6 @@
   &__heading {
     position: relative;
     font-weight: normal;
-    a:visited {
-      color: $link-colour;
-    }
 
     &__asc, &__desc {
       font-weight: bold;
@@ -133,14 +121,6 @@
   }
 }
 
-.pagination span a:visited {
-  color: $link-colour;
-}
-
-a.danger, a.danger:visited {
-  color: $error-colour;
-}
-
 // =============================================================================
 // Tabs
 
@@ -152,18 +132,13 @@ a.danger, a.danger:visited {
     margin: 0;
     padding: 15px;
     border-width: 1px 1px 0px 1px;
-    border-color: $grey-2;
     border-style: solid;
-    background: $page-colour;
   }
   > div {
     display: inline-block;
     margin: 0;
     padding: 15px;
     padding-bottom: 14px;
-  }
-  a:visited {
-    color: $link-colour;
   }
 
   &__ie-fix {
@@ -173,11 +148,9 @@ a.danger, a.danger:visited {
     left: 0px;
     width: 100%;
     height: 20px;
-    background: $page-colour;
   }
 
   &__content {
-    border-top: 1px solid $grey-2;
     padding-top: 1em;
   }
 }
@@ -188,12 +161,6 @@ a.danger, a.danger:visited {
 
 .dgu-masthead {
   margin: 0;
-  background: $alpine-fresh;
-  color: $page-colour;
-
-  a {
-    color: $page-colour;
-  }
 
   &__login-white {
     line-height: 42px;
@@ -201,8 +168,6 @@ a.danger, a.danger:visited {
 
   &__button-get-started {
     @include bold-24;
-    color: $alpine-fresh!important;
-    background-color: $page-colour!important;
     background-image: url(asset-path("icon-pointer-green.png"));
     background-repeat: no-repeat;
     background-position: 95% 50%;
@@ -242,17 +207,13 @@ a.danger, a.danger:visited {
 
   &__alert {
     display: inline-block;
-    color: $error-colour;
-    border-left: 4px solid $error-colour;
     padding-left: 10px;
     margin-left: 2px;
   }
 
   &__table {
     margin-bottom: 2em;
-    tbody tr:hover {
-      background-color: $panel-colour;
-    }
+
     thead td, tbody td {
       padding-left: .3em;
       padding-right: .3em;
@@ -287,7 +248,6 @@ a.danger, a.danger:visited {
 .dgu-user-details {
   li {
     margin-bottom: 1em;
-    border-bottom: 1px solid $grey-2;
   }
   &__label {
     display: inline-block;

--- a/app/assets/stylesheets/govuk-overrides.scss
+++ b/app/assets/stylesheets/govuk-overrides.scss
@@ -59,10 +59,6 @@ div#global-header-bar {
   max-width: 960px;
 }
 
-.govuk-box-highlight a {
-  color: $white;
-}
-
 .form-date .form-group.form-group-day.form-group-error {
   width: 130px;
   input { width: 50px; }
@@ -99,7 +95,6 @@ span.error.error-message {
 
 span.separator::before {
   content: " | ";
-  color: $grey-1;
 }
 
 ul.classic {
@@ -120,7 +115,6 @@ table {
 }
 
 a.secondary-button, a.secondary-button:visited {
-  color: $link-colour;
   cursor: pointer;
   text-decoration: underline;
 }
@@ -135,9 +129,6 @@ nav ul {
     margin-bottom: 1em;
     a {
       text-decoration: none;
-      &:visited {
-        color: $link-colour;
-      }
     }
   }
 }

--- a/app/views/manage/manage_own.html.erb
+++ b/app/views/manage/manage_own.html.erb
@@ -1,5 +1,5 @@
 <% if flash[:success] %>
-<div class="govuk-box-highlight">
+<div>
   <h1 class="bold-large"><%= flash[:success] %></h1>
   <h2>
     <%= link_to "View it", find_url(flash['extra']['uuid'], flash['extra']['name']) %>


### PR DESCRIPTION
This app use the `govuk_frontend_toolkit` for its styles,
but recently has been having trouble finding variables such as
$link-colour, which is blocking deployments.

As we don't need to access Publish via the frontend we can
remove references to these variables in the affected Sass files.

Trello card: https://trello.com/c/LhIWTWKQ/1693-3-remove-dependency-which-is-blocking-deployment-of-dgu-publish