### PR TITLE
Don't deploy the frontend as its not in use

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-cf zero-downtime-push publish-data-beta-production -f production-app-manifest.yml --show-app-log=true
 cf zero-downtime-push publish-data-beta-production-worker -f production-worker-manifest.yml --show-app-log=true

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -2,5 +2,4 @@
 
 set -e
 
-cf zero-downtime-push publish-data-beta-staging -f staging-app-manifest.yml --show-app-log=true
 cf zero-downtime-push publish-data-beta-staging-worker -f staging-worker-manifest.yml --show-app-log=true


### PR DESCRIPTION
## What 

There's no need to deploy the frontend part of Publish as we only need the workers to synchronise CKAN solr and DGU elasticsearch.