### PR TITLE
Remove frontend deployment from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,19 +30,10 @@ after_success:
 deploy:
   # To Staging
   - provider: script
-    script: scripts/deploy.sh publish-data-beta-staging staging app
-    on:
-      repo: alphagov/datagovuk_publish
-  - provider: script
     script: scripts/deploy.sh publish-data-beta-staging-worker staging worker
     on:
       repo: alphagov/datagovuk_publish
   # To Production
-  - provider: script
-    script: scripts/deploy.sh publish-data-beta-production production app
-    on:
-      repo: alphagov/datagovuk_publish
-      tags: true
   - provider: script
     script: scripts/deploy.sh publish-data-beta-production-worker production worker
     on:


### PR DESCRIPTION
## What

Had thought it was removed when we took out the deployment from the deploy scripts but we also need to remove it from the travis file