### PR TITLE
Lower threshold of MAX_DELETIONS limit

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 1500
+      MAX_DELETIONS = 100
 
       def self.depaginate(*args)
         self.new(*args).depaginate


### PR DESCRIPTION
Reverts the revert here -
https://github.com/alphagov/datagovuk_publish/pull/890/files.

This threshold was changed to 1500 to allow a legitimate mass deletion
of datasets from Barnet Council, however we now need to change this back
to preserve find from deleting datasets when there is a miscommunication
between it and CKAN.

Related incident:
https://docs.google.com/document/d/13WprBbnTbef4gisSa0EoYpXjP_ZRmujoYAHx3o_DlLQ/edit#