### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
 script:
   - bundle exec rails db:create
   - bundle exec rails db:schema:load
+  - bundle exec rubocop app spec lib Gemfile
   - bundle exec rake
   - bundle exec codeclimate-test-reporter
 env:

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,4 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task default: %i(spec lint brakeman)
+task default: %i(spec brakeman)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run rubocop"
-task "lint" do
-  sh "rubocop --format clang app lib spec test Gemfile"
-end


### PR DESCRIPTION
- Now we don't use `govuk-lint` to wrap RuboCop, we _could_ switch this
  to run `bundle exec rubocop`, but that's not very useful as it hides
  the directories that it operates on, and we're trying to move away
  from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.
- Now there's no `lint` Rake task, we have to run `rubocop` on CI
  directly.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it as part of the developer tooling group