### PR TITLE
Filter out test publisher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
 # This Dockerfile is used with the docker-ckan dev stack
 FROM ruby:2.6.6
 
-WORKDIR /srv/app/src_extensions/datagovuk_publish
+WORKDIR /srv/app/datagovuk_publish
 
 RUN apt-get update
 RUN apt-get install -y nodejs postgresql postgresql-contrib
 
-COPY ./ /srv/app/src_extensions/datagovuk_publish
+# To allow tests to be run with the test database
+ENV DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL true
+
+COPY ./ /srv/app/datagovuk_publish
 
 RUN gem install bundler --conservative && \
     bundle install

--- a/app/services/ckan/v26/package_differ.rb
+++ b/app/services/ckan/v26/package_differ.rb
@@ -3,7 +3,7 @@ require "ckan/v26/client"
 module CKAN
   module V26
     class PackageDiffer
-      CKAN_FIELDS = %i[id metadata_modified].freeze
+      CKAN_FIELDS = %i[id metadata_modified organization].freeze
 
       def call
         datasets = Dataset.where.not(legacy_name: nil)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -88,4 +88,5 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.ckan_v26_base_url = "https://ckan.publishing.service.gov.uk"
+  config.test_publisher = "test-valley-borough-council"
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -3,4 +3,5 @@ require_relative "./production"
 Rails.application.configure do
   config.assets.compile = true
   config.ckan_v26_base_url = "https://ckan.staging.publishing.service.gov.uk"
+  config.test_publisher = ""
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -50,4 +50,5 @@ Rails.application.configure do
   end)
 
   config.ckan_v26_base_url = "http://ckan"
+  config.test_publisher = "test-publisher"
 end

--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -76,7 +76,7 @@ module CKAN
           end
         end
 
-        results
+        results.reject { |h| h["organization"] == Rails.configuration.test_publisher }
       end
 
     private

--- a/production-app-manifest.yml
+++ b/production-app-manifest.yml
@@ -2,7 +2,7 @@ applications:
 - name: publish-data-beta-production
   command: bundle exec rake db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.17
   stack: cflinuxfs3
   env:
     RAILS_ENV: production

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-production-worker
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.17
   stack: cflinuxfs3
   command: bundle exec sidekiq
   env:

--- a/spec/fixtures/files/ckan/v26/search_dataset_p1.json
+++ b/spec/fixtures/files/ckan/v26/search_dataset_p1.json
@@ -1,21 +1,30 @@
 {
-    "count": 4,
+    "count": 5,
     "results": [
         {
             "id": "7509bbb5-ce6a-4801-8d77-b72c58d46180",
+            "organization": "aberdeen-city-council",
             "metadata_modified": "2018-03-18T09:03:05.821Z"
         },
         {
             "id": "fa37dff7-bbc0-4a84-a146-7eee332c9c1f",
+            "organization": "aberdeen-city-council",
             "metadata_modified": "2017-06-23T16:34:35.694Z"
         },
         {
             "id": "bca22660-dccc-4a37-9cfe-6bc2c0739cff",
+            "organization": "aberdeen-city-council",
             "metadata_modified": "2018-05-02T19:27:59.746Z"
         },
         {
             "id": "5f6e6b90-e83b-4998-8682-e427ddc7493a",
+            "organization": "aberdeen-city-council",
             "metadata_modified": "2018-01-01T00:00:01.000Z"
+        },
+        {
+            "id": "b09659af-2d8f-4dd4-9e50-453160a6b1d6",
+            "organization": "test-publisher",
+            "metadata_modified": "2020-03-26T00:00:01.000Z"
         }
     ]
 }

--- a/spec/fixtures/files/ckan/v26/search_dataset_p2.json
+++ b/spec/fixtures/files/ckan/v26/search_dataset_p2.json
@@ -1,4 +1,4 @@
 {
-    "count": 4,
+    "count": 5,
     "results": [ ]
 }

--- a/staging-app-manifest.yml
+++ b/staging-app-manifest.yml
@@ -2,7 +2,7 @@ applications:
 - name: publish-data-beta-staging
   command: bundle exec rake db:migrate db:seed && bin/rails server -b 0.0.0.0 -p $PORT -e $RAILS_ENV
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.17
   stack: cflinuxfs3
   env:
     RAILS_ENV: staging

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-data-beta-staging-worker
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.7.40
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.17
   stack: cflinuxfs3
   command: bundle exec sidekiq
   env:


### PR DESCRIPTION
## What 

Filter out test publisher to prevent it from being harvested and pushed to the data.gov.uk Find frontend. 

Also update the buildpack for deployment as we upgraded to Ruby 2.6.6

## Reference 

https://trello.com/c/bi425MX0/135-block-data-from-test-publisher-on-ckan-from-reaching-dgu-find