### PR TITLE
rubocop: Remove redundant configs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,22 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-AllCops:
-  TargetRubyVersion: 2.5
-  Exclude:
-    - bin/**/*
-    - config.ru
-    - db/schema.rb
-    - db/migrate/*
-    - vendor/**/*
-    - lib/ckan/v26/depaginator.rb
-
-Metrics/BlockLength:
-  Exclude:
-    - 'config/routes.rb'
-    - 'lib/tasks/**/*.rake'
-    - 'spec/**/*.rb'
-
-Layout/MultilineMethodCallBraceLayout:
-  Enabled: false

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,8 @@ private
       params: params.to_unsafe_h,
       url: request.url,
       environment: Rails.env,
-      app_environment: ENV["VCAP_APPLICATION"])
+      app_environment: ENV["VCAP_APPLICATION"],
+    )
 
     return unless current_user
 
@@ -34,6 +35,7 @@ private
       name: current_user.name,
       email: current_user.email,
       organisation_id: current_user.primary_organisation.id,
-      organisation: current_user.primary_organisation.name)
+      organisation: current_user.primary_organisation.name,
+    )
   end
 end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -60,7 +60,8 @@ class Dataset < ApplicationRecord
         datafiles: {},
         docs: {},
         inspire_dataset: {},
-      })
+      },
+    )
   end
 
   def creator

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,7 +17,8 @@ Topic.find_or_create_by(name: "transport", title: "Transport")
 puts "Seeding organisations"
 org = Organisation.find_or_create_by(
   uuid: "90aefa0d-0e92-4895-a7fd-c1adb2b3f14f",
-  name: "government-digital-service")
+  name: "government-digital-service",
+)
 
 org.update_attribute(:govuk_content_id, "af07d5a5-df63-4ddc-9383-6a666845ebe9")
 org.update_attribute(:title, "Government Digital Service")
@@ -26,4 +27,5 @@ puts "Seeding users"
 User.find_or_create_by(
   email: "publisher@example.com",
   name: "Publisher",
-  organisation_content_id: org.govuk_content_id)
+  organisation_content_id: org.govuk_content_id,
+)

--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -1,4 +1,4 @@
-require 'ckan/modules/url_builder'
+require "ckan/modules/url_builder"
 
 module CKAN
   module V26
@@ -8,7 +8,7 @@ module CKAN
       MAX_DELETIONS = 100
 
       def self.depaginate(*args)
-        self.new(*args).depaginate
+        new(*args).depaginate
       end
 
       def initialize(base_url, existing_total:)
@@ -28,28 +28,24 @@ module CKAN
           total_expected_from_first_response ||= total_expected
 
           if total_expected != total_expected_from_first_response
-            raise ExpectedTotalChangedError.new(
-              <<~MESSAGE
-                New expected count `#{total_expected}` from CKAN does not match
-                the original expected count of `#{total_expected_from_first_response}`.
+            raise ExpectedTotalChangedError, <<~MESSAGE
+              New expected count `#{total_expected}` from CKAN does not match
+              the original expected count of `#{total_expected_from_first_response}`.
 
-                CKAN response:
-                #{raw_response}
-              MESSAGE
-            )
+              CKAN response:
+              #{raw_response}
+            MESSAGE
           end
 
           results.concat(page)
 
           if results.count > total_expected
-            raise MoreResultsThanExpectedError.new(
-              <<~MESSAGE
-                We have received more results (#{results.count}) than expected (#{total_expected}).
+            raise MoreResultsThanExpectedError, <<~MESSAGE
+              We have received more results (#{results.count}) than expected (#{total_expected}).
 
-                CKAN response:
-                #{raw_response}
-              MESSAGE
-            )
+              CKAN response:
+              #{raw_response}
+            MESSAGE
           end
 
           if page.empty?
@@ -59,27 +55,23 @@ module CKAN
               if number_being_deleted <= MAX_DELETIONS
                 break
               else
-                raise DeletionTooLargeError.new(
-                  <<~MESSAGE
-                    Attempting to delete `#{number_being_deleted}` datasets.
+                raise DeletionTooLargeError, <<~MESSAGE
+                  Attempting to delete `#{number_being_deleted}` datasets.
 
-                    No more than #{MAX_DELETIONS} datasets can be deleted at once.
-
-                    CKAN response:
-                    #{raw_response}
-                  MESSAGE
-                )
-              end
-            else
-              raise EarlyEmptyPageError.new(
-                <<~MESSAGE
-                  We have received an empty page but have only received `#{results.count}`
-                  results rather than the expected `#{total_expected}` results.
+                  No more than #{MAX_DELETIONS} datasets can be deleted at once.
 
                   CKAN response:
                   #{raw_response}
                 MESSAGE
-              )
+              end
+            else
+              raise EarlyEmptyPageError, <<~MESSAGE
+                We have received an empty page but have only received `#{results.count}`
+                results rather than the expected `#{total_expected}` results.
+
+                CKAN response:
+                #{raw_response}
+              MESSAGE
             end
           end
         end
@@ -89,11 +81,7 @@ module CKAN
 
     private
 
-      attr_reader *%i[
-        base_url
-        existing_total
-        results
-      ]
+      attr_reader(:base_url, :existing_total, :results)
 
       class ExpectedTotalChangedError < StandardError; end
       class MoreResultsThanExpectedError < StandardError; end

--- a/spec/features/dataset_edit_spec.rb
+++ b/spec/features/dataset_edit_spec.rb
@@ -10,7 +10,8 @@ describe "editing datasets" do
       :with_datafile,
       :with_doc,
       organisation: land,
-      creator: user)
+      creator: user,
+    )
   end
 
   before(:each) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,8 @@ RSpec.configure do |config|
       index_alias: "datasets-test",
       client: Dataset.__elasticsearch__.client,
       logger: Rails.logger,
-      indices_to_keep: 0).run
+      indices_to_keep: 0,
+    ).run
   end
 
   config.before(:each) do

--- a/spec/services/alias_updater_service_spec.rb
+++ b/spec/services/alias_updater_service_spec.rb
@@ -8,7 +8,8 @@ describe AliasUpdaterService do
       new_index_name: "new_index",
       index_alias: "my_alias",
       client: client,
-      logger: Rails.logger)
+      logger: Rails.logger,
+    )
   end
 
   describe "#run" do


### PR DESCRIPTION
The `rubocop-govuk` gem has moved on a bit since these excludes in
`.rubocop.yml` were written. As part of standardizing our RuboCop
configs across all the repos - because otherwise what's the point of
having a set of rules? - this removes all the special excludes and
fixes the new failures.

