### PR TITLE
Add Dockerfile, setup-docker and docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# This Dockerfile is used with the docker-ckan dev stack
+FROM ruby:2.6.6
+
+WORKDIR /srv/app/src_extensions/datagovuk_publish
+
+RUN apt-get update
+RUN apt-get install -y nodejs postgresql postgresql-contrib
+
+COPY ./ /srv/app/src_extensions/datagovuk_publish
+
+RUN gem install bundler --conservative && \
+    bundle install

--- a/bin/setup-docker.sh
+++ b/bin/setup-docker.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This setup script is used with the docker-ckan dev stack
+
+echo '===== Setup datagovuk publish ====='
+
+RETRIES=10
+until psql -h db -U ckan -d ckan -c "select 1" > /dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+    echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
+    sleep 1
+done
+
+bin/rails db:setup
+rails db:environment:set RAILS_ENV=development
+
+# wait until elasticsearch is running
+until [ "$health" = 'yellow' -o "$health" = 'green' ]; do
+    health="$(curl -fsSL "elasticsearch:9200/_cat/health?h=status")"
+    if [ "$health" != 'yellow' -a "$health" != 'green' ]; then
+        echo "Elastic Search is unavailable - sleeping"
+        sleep 1
+    fi
+done
+
+bin/rails search:reindex
+mkdir -p /var/log/sidekiq
+bundle exec sidekiq 2>&1 | tee /var/log/sidekiq/sidekiq.log

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,7 +4,7 @@ default: &default
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   url: <%= ENV['DATABASE_URL'] %>
 
-development:
+development: &development
   <<: *default
   database: publish_data_beta_development
 

--- a/config/elasticsearch.yml
+++ b/config/elasticsearch.yml
@@ -8,7 +8,7 @@ test:
 development:
   <<: *default
   host: <%= ENV["ES_HOST"] || "http://localhost:9200" %>
-
+  
 integration:
   <<: *default
   host: <%= ENV["BONSAI_URL"] %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -54,5 +54,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.ckan_v26_base_url = "https://data.gov.uk"
+  config.ckan_v26_base_url = ENV.fetch("CKAN_URL") { "https://data.gov.uk" }
 end

--- a/config/redis.yml
+++ b/config/redis.yml
@@ -4,7 +4,7 @@ default: &default
 development:
   <<: *default
   namespace: development
-  host: localhost
+  host: '<%= ENV["REDIS_HOST"] || 'localhost' %>'
   port: 6379
 
 test:

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -7,6 +7,15 @@
   sync: 1
   import: <%= ENV.fetch('RAILS_MAX_THREADS') { 5 } - 1 %>
 
+development:
+  :schedule:
+    ckan_v26_package_sync:
+      class: CKAN::V26::PackageSyncWorker
+      cron: '*/10 * * * *'
+    ckan_v26_ckan_org_sync:
+      class: CKAN::V26::CKANOrgSyncWorker
+      cron: '*/10 * * * *'
+
 staging:
   :schedule:
     ckan_v26_package_sync:


### PR DESCRIPTION
## What

In order to get Publish to run in the alphgov/docker-ckan
dev stack it is necessary to add these files and add in environment vars for
redis and ckan hosts so that it is still possible to run Publish as a standalone app.