### PR TITLE
Add test_publisher config to dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.ckan_v26_base_url = ENV.fetch("CKAN_URL") { "https://data.gov.uk" }
+  config.test_publisher = ""
 end


### PR DESCRIPTION
## What

`test_publisher` config setting was missed off the development config setting causing the app to break, so adding it in will enable the sidekiq workers to run.