### PR TITLE
Update setup-docker to check that CKAN is running

### DIFF
--- a/bin/setup-docker.sh
+++ b/bin/setup-docker.sh
@@ -23,4 +23,13 @@ done
 
 bin/rails search:reindex
 mkdir -p /var/log/sidekiq
+
+until [ "$health" = 'OK' ]; do
+    health="$(curl -fsSL "$CKAN_URL/healthcheck")"
+    if [ "$health" != 'OK' ]; then
+        echo "CKAN is unavailable - sleeping"
+        sleep 10
+    fi
+done
+
 bundle exec sidekiq 2>&1 | tee /var/log/sidekiq/sidekiq.log


### PR DESCRIPTION
## What

Before running sidekiq the added code will check that CKAN is running, otherwise sidekiq will flood the console with errors .

