### PR TITLE
Only run rubocop under development or test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,14 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require_relative "config/application"
-require "rubocop/rake_task"
+
+tasks = %i[spec brakeman]
+if Rails.env.development? || Rails.env.test?
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+  tasks = %i[spec brakeman rubocop]
+end
 
 Rails.application.load_tasks
-RuboCop::RakeTask.new
 
-task default: %i[spec brakeman rubocop]
+task default: tasks

--- a/spec/lib/tasks/update_organogram_filenames_spec.rb
+++ b/spec/lib/tasks/update_organogram_filenames_spec.rb
@@ -33,8 +33,10 @@ describe UpdateOrganogramFilenames do
 
       update_organogram_filenames.replace_urls
 
-      expect(Link.all[0].url).to eql("https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv")
-      expect(Link.all[1].url).to eql("https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv")
+      expect(Link.all.length).to be(2)
+      expect(Link.all.map(&:url)).to include(
+        "https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-senior.csv", "https://s3-eu-west-1.amazonaws.com/datagovuk/dataset/resources/2019-06-06T11-18-26Z-organogram-junior.csv"
+      )
     end
   end
 end


### PR DESCRIPTION
## What

Rubocop is not available when deploying to staging or production so don't run the require rubocop or run the rake task if it isn't available.