### PR TITLE
Temporarily increase max deletions to 500

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 100
+      MAX_DELETIONS = 500
 
       def self.depaginate(*args)
         new(*args).depaginate


### PR DESCRIPTION
## What

In order to run the CKAN functional tests, some existing test data had to be removed which may have caused the MAX_DELETIONS threshold to be hit, so temporarily increase it to 500 to allow test data to be removed.