### PR TITLE
Add DeletionTooLargeError and up MAX_DELETIONS

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 500
+      MAX_DELETIONS = 1000
 
       def self.depaginate(*args)
         new(*args).depaginate
@@ -83,6 +83,7 @@ module CKAN
 
       attr_reader(:base_url, :existing_total, :results)
 
+      class DeletionTooLargeError < StandardError; end
       class ExpectedTotalChangedError < StandardError; end
       class MoreResultsThanExpectedError < StandardError; end
       class EarlyEmptyPageError < StandardError; end


### PR DESCRIPTION
## What

Add in the definition for DeletionTooLargeError as it is throwing errors and up the limit to 1000 as it seems like there are lots of deletions.