### PR TITLE
Temp up the MAX DELETIONS to 10000

### DIFF
--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -5,7 +5,7 @@ module CKAN
     class Depaginator
       include CKAN::Modules::URLBuilder
 
-      MAX_DELETIONS = 1000
+      MAX_DELETIONS = 10000
 
       def self.depaginate(*args)
         new(*args).depaginate


### PR DESCRIPTION
## What

Up the MAX_DELETIONS to 10,000 as it seems like the solr reindex / db rebuild may have caused the number of datasets to be changed.