### PR TITLE
Remove acronym inflection for API

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -12,6 +12,5 @@
 
 # These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym "API"
   inflect.acronym "CKAN"
 end


### PR DESCRIPTION
This was added in d021903 to namespace certain controllers but this no longer applies. However it has the unfortunate side-effect of breaking the gds-sso gem's namespacing for the user controller because it uses the title-case variant 'Api::UsersController'. When the zeitwerk autoloader sees the acronym and the api directory it auto generates the module 'API' but then runs into problems trying to generate the controller and raises a NameError for the constant 'Api'. We can remove the acronym as there is no longer anything namespaced under 'API' within this app.