### PR TITLE
Upgrade to ruby 2.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby IO.read(".ruby-version").strip
-
 gem "rails", "6.0.3.2"
 
 gem "audited"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -503,8 +503,5 @@ DEPENDENCIES
   webmock
   whois-parser
 
-RUBY VERSION
-   ruby 2.6.6
-
 BUNDLED WITH
    1.17.3

--- a/lib/ckan/v26/depaginator.rb
+++ b/lib/ckan/v26/depaginator.rb
@@ -7,8 +7,8 @@ module CKAN
       # temp increase to 10000, should normally be 100
       MAX_DELETIONS = 10_000
 
-      def self.depaginate(*args)
-        new(*args).depaginate
+      def self.depaginate(*args, **kwargs)
+        new(*args, **kwargs).depaginate
       end
 
       def initialize(base_url, existing_total:)


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7.1

Since there is a script to change all apps' versions automatically, leaving the Ruby version at 2.6.6 in this PR.

There are some deprecation warnings coming from the Kaminari gem, but there is a note in the Gemfile not to update it unless ElasticSearch is updated, which seems like a separate issue