### PR TITLE
Use postgres 12 

### DIFF
--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -9,7 +9,7 @@ applications:
     RACK_ENV: production
   services:
   - publish-production-secrets
-  - publish-beta-production-pg
+  - publish-beta-production-pg-12
   - publish-beta-production-redis
   - logit-ssl-drain
   - elasticsearch-7-production

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -9,7 +9,7 @@ applications:
     RACK_ENV: staging
   services:
   - publish-staging-secrets
-  - publish-beta-staging-pg
+  - publish-beta-staging-pg-12
   - publish-beta-staging-redis
   - logit-ssl-drain
   - elasticsearch-7-staging


### PR DESCRIPTION
## What

Use Postgres 12 and not Postgres 9.5 is being withdrawn from paas because its no longer being supported.