### PR TITLE
Double allowed upload size to 50 MB

### DIFF
--- a/config/production/nginx.conf
+++ b/config/production/nginx.conf
@@ -80,7 +80,7 @@ server {
   add_header X-Frame-Options SAMEORIGIN;
 
   charset utf-8;
-  client_max_body_size 25M;
+  client_max_body_size 50M;
   limit_req_status 429;
   port_in_redirect off;
 

--- a/config/staging/nginx.ckan.conf
+++ b/config/staging/nginx.ckan.conf
@@ -80,7 +80,7 @@ server {
   add_header X-Frame-Options SAMEORIGIN;
 
   charset utf-8;
-  client_max_body_size 25M;
+  client_max_body_size 50M;
   port_in_redirect off;
 
   gzip on;


### PR DESCRIPTION
We received a ticket (https://govuk.zendesk.com/agent/tickets/4707289) in which the user described seeing an Nginx error message '413 Request Entity Too Large' when uploading a 30mb file. I was able to reproduce this error.