### PR TITLE
Correctly assign updated date to links

### DIFF
--- a/app/services/ckan/v26/link_mapper.rb
+++ b/app/services/ckan/v26/link_mapper.rb
@@ -7,7 +7,7 @@ module CKAN
           format: resource.get("format"),
           name: build_name(resource),
           created_at: build_created_at(resource, dataset),
-          updated_at: build_created_at(resource, dataset),
+          updated_at: build_updated_at(resource, dataset),
           type: build_type(resource),
           dataset_id: dataset.id,
         }
@@ -20,6 +20,13 @@ module CKAN
         return created if created.present?
 
         dataset.created_at
+      end
+
+      def build_updated_at(resource, dataset)
+        updated = resource.get("metadata_modified")
+        return updated if updated.present?
+
+        dataset.updated_at
       end
 
       def build_name(resource)

--- a/spec/factories/ckan_v26_resource.rb
+++ b/spec/factories/ckan_v26_resource.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     name { "Resource locator" }
     description { "Resource locator" }
     created { "2016-04-05T09:48:43.164470" }
+    metadata_modified { "2017-04-05T09:48:43.164470" }
     resource_type { "file" }
 
     initialize_with do

--- a/spec/services/ckan/v26/link_mapper_spec.rb
+++ b/spec/services/ckan/v26/link_mapper_spec.rb
@@ -12,7 +12,7 @@ describe CKAN::V26::LinkMapper do
       expect(attributes[:format]).to eq resource.get("format")
       expect(attributes[:name]).to eq resource.get("name")
       expect(attributes[:created_at]).to eq resource.get("created")
-      expect(attributes[:updated_at]).to eq resource.get("created")
+      expect(attributes[:updated_at]).to eq resource.get("metadata_modified")
       expect(attributes[:type]).to eq "Datafile"
     end
 
@@ -38,7 +38,12 @@ describe CKAN::V26::LinkMapper do
       resource = build :ckan_v26_resource, created: ""
       attributes = subject.call(resource, dataset)
       expect(attributes[:created_at]).to eq dataset.created_at
-      expect(attributes[:updated_at]).to eq dataset.created_at
+    end
+
+    it "uses the dataset modified time if the resource has none" do
+      resource = build :ckan_v26_resource, metadata_modified: ""
+      attributes = subject.call(resource, dataset)
+      expect(attributes[:updated_at]).to eq dataset.updated_at
     end
   end
 end


### PR DESCRIPTION
We are currently assigning the `created` date from CKAN to both the `created_at` and `updated_at` values for links in the frontend of data.gov.uk.

This leads to a situation where publishers update data in CKAN, but the updated date does not change on DGU Find as it remains fixed on the creation date.

Making this change to correctly set the updated date.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/4751177)