### PR TITLE
Update build_type method to use correct API

### DIFF
--- a/app/services/ckan/v26/link_mapper.rb
+++ b/app/services/ckan/v26/link_mapper.rb
@@ -40,8 +40,8 @@ module CKAN
       end
 
       def build_type(resource)
-        type = resource.get("resource_type")
-        type == "documentation" ? "Doc" : "Datafile"
+        type = resource.get("resource-type")
+        type == "supporting-document" ? "Doc" : "Datafile"
       end
     end
   end

--- a/spec/fixtures/files/ckan/v26/package_show_update.json
+++ b/spec/fixtures/files/ckan/v26/package_show_update.json
@@ -112,7 +112,7 @@
                 "position": 1,
                 "revision_id": "a0372fbf-c991-436c-b0a5-744d499054ee",
                 "id": "b7e53746-1154-425d-a85d-5bb03eb3f310",
-                "resource_type": "documentation",
+                "resource-type": "supporting-document",
                 "name": "Landing page"
             }
         ],
@@ -196,7 +196,7 @@
                 "position": 1,
                 "revision_id": "a0372fbf-c991-436c-b0a5-744d499054ee",
                 "id": "b7e53746-1154-425d-a85d-5bb03eb3f310",
-                "resource_type": "documentation",
+                "resource-type": "supporting-document",
                 "name": "Landing page"
             }
         ],

--- a/spec/services/ckan/v26/link_mapper_spec.rb
+++ b/spec/services/ckan/v26/link_mapper_spec.rb
@@ -17,7 +17,7 @@ describe CKAN::V26::LinkMapper do
     end
 
     it "correctly distinguishes between datafiles and docs" do
-      resource = build :ckan_v26_resource, resource_type: "documentation"
+      resource = build :ckan_v26_resource, "resource-type": "supporting-document"
       attributes = subject.call(resource, dataset)
       expect(attributes[:type]).to eq "Doc"
     end


### PR DESCRIPTION
## What
Updates how the `build_type` interprets CKAN API responses when looking for supporting documents.

## Why
Missed update from the most recent CKAN upgrade. Detailed explanation from Bruce via [this zendesk ticket](https://govuk.zendesk.com/agent/tickets/4770524):

>It appears the API response from CKAN is different to what we're using to import to DGU.  I remember this being flagged as a post-CKAN upgrade issue, but presumably never got fixed.
>
>Example API response (see value for `resource-type` for each link, it shows whether it should be a dataset or supporting link):
>https://ckan.publishing.service.gov.uk/api/action/package_show?id=d0be1ed2-9907-4ec4-b552-c048f6aec16a
>
>What we're expecting:
>https://github.com/alphagov/datagovuk_publish/blob/30229772be42b054a85c97037c4eaaaeafa16ee0/app/services/ckan/v26/link_mapper.rb#L37
>
>We need to update the importer to use `resource-type` instead of `resource_type`, then `supporting-document` instead of `documentation`.  Then re-run an import of all documents to DGU from CKAN.