### PR TITLE
Temporarily update MAX_DELETIONS to 4100

### DIFF
--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 100
+      MAX_DELETIONS = 4100
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate


### PR DESCRIPTION
## What

Expecting just over 4000 deletions due to duplicate datasets being removed. After the duplicate datasets have been removed MAX_DELETIONS should be set back to 100.

## Reference 

https://trello.com/c/5LSihxlF/1139-investigate-and-fix-duplicate-datasets