### PR TITLE
Revert "Temporarily update MAX_DELETIONS to 4100"

### DIFF
--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 4100
+      MAX_DELETIONS = 100
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate


### PR DESCRIPTION
## What 

Reverts alphagov/datagovuk_publish#1163

Now that the deletions have been applied we can revert back to 100 max deletions

## Reference

https://trello.com/c/5LSihxlF/1139-investigate-and-fix-duplicate-datasets