### PR TITLE
Update manifests to use redis 6

### DIFF
--- a/integration-worker-manifest.yml
+++ b/integration-worker-manifest.yml
@@ -10,7 +10,7 @@ applications:
   services:
   - publish-integration-secrets
   - publish-beta-integration-pg-12
-  - publish-beta-integration-redis
+  - publish-beta-integration-redis-6
   - logit-ssl-drain
   - opensearch-integration
   health-check-type: process

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -10,7 +10,7 @@ applications:
   services:
   - publish-production-secrets
   - publish-beta-production-pg-12
-  - publish-beta-production-redis
+  - publish-beta-production-redis-6
   - logit-ssl-drain
   - opensearch-production
   health-check-type: process

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -10,7 +10,7 @@ applications:
   services:
   - publish-staging-secrets
   - publish-beta-staging-pg-12
-  - publish-beta-staging-redis
+  - publish-beta-staging-redis-6
   - logit-ssl-drain
   - opensearch-staging
   health-check-type: process


### PR DESCRIPTION
Redis 3 is being withdrawn from PaaS, so upgrade to redis 6