### PR TITLE
Increase MAX_DELETIONS to 16495

### DIFF
--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 100
+      MAX_DELETIONS = 16_495
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate


### PR DESCRIPTION
Staging stack is stuck as there are a large number of deletions required to keep Find and CKAN in sync so allow the deletions for Staging.