### PR TITLE
Update ruby buildpack to 1.10.4 for ruby 3.2.2

### DIFF
--- a/integration-worker-manifest.yml
+++ b/integration-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-beta-integration-worker
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.9.3
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.10.4
   stack: cflinuxfs3
   command: bundle exec rake db:migrate db:seed && bundle exec sidekiq
   env:

--- a/production-worker-manifest.yml
+++ b/production-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-beta-production-worker
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.9.3
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.10.4
   stack: cflinuxfs3
   command: bundle exec rake db:migrate db:seed && bundle exec sidekiq
   env:

--- a/staging-worker-manifest.yml
+++ b/staging-worker-manifest.yml
@@ -1,7 +1,7 @@
 applications:
 - name: publish-beta-staging-worker
   memory: 1G
-  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.9.3
+  buildpack: https://github.com/cloudfoundry/ruby-buildpack.git#v1.10.4
   stack: cflinuxfs3
   command: bundle exec rake db:migrate db:seed && bundle exec sidekiq
   env:


### PR DESCRIPTION
Ruby 3.2.2 isn't available in ruby-buildpack 1.9.3 so upgrade to 1.10.4