### PR TITLE
Update redis host k8s

### DIFF
--- a/config/redis.yml
+++ b/config/redis.yml
@@ -15,15 +15,15 @@ test:
 
 integration:
   <<: *default
-  url: '<%= JSON.parse(ENV["VCAP_SERVICES"] || "{}")
+  url: '<%= ENV["REDIS_HOST"] || JSON.parse(ENV["VCAP_SERVICES"] || "{}")
                 .dig("redis", 0, "credentials", "uri") %>'
 
 staging:
   <<: *default
-  url: '<%= JSON.parse(ENV["VCAP_SERVICES"] || "{}")
-                .dig("redis", 0, "credentials", "uri") %>'
+  url: '<%= ENV["REDIS_HOST"] || JSON.parse(ENV["VCAP_SERVICES"] || "{}")
+                .dig("redis", 0, "credentials", "uri")%>'
 
 production:
   <<: *default
-  url: '<%= JSON.parse(ENV["VCAP_SERVICES"] || "{}")
+  url: '<%= ENV["REDIS_HOST"] || JSON.parse(ENV["VCAP_SERVICES"] || "{}")
                 .dig("redis", 0, "credentials", "uri") %>'


### PR DESCRIPTION
Kubernetes cluster doesn't have VCAP_SERVICES env var, just use the REDIS_HOST env var if available.