### PR TITLE
Add build-image-on-tags GitHub action

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -1,0 +1,29 @@
+name: Build and push images on tags
+
+on:
+  push:
+    tags:
+      - 'k[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build_and_push:
+    name: datagovuk-publish
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a  # v2.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.gitRef }}
+      - name: Build and push images
+        env:
+          APP: datagovuk_publish
+          ARCH: amd64
+          GH_REF: ${{ github.ref_name }}
+        run: ./docker/build-image.sh

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -12,6 +12,10 @@ build () {
 
 DOCKER_TAG="${GITHUB_SHA}"
 
+if [[ -n ${GH_REF:-} ]]; then
+  DOCKER_TAG="${GH_REF}"
+fi
+
 build "${DOCKER_TAG}"
 
 if [[ -n ${DRY_RUN:-} ]]; then


### PR DESCRIPTION
Description:
- Adds a GitHub Action to build the docker image but tagged
- Use 'k' instead of 'v' to avoid clashing with the existing docker images as this isn't ready to release without testing yet