### PR TITLE
Add create-pr-on-tags action

### DIFF
--- a/.github/workflows/build-image-on-tags.yaml
+++ b/.github/workflows/build-image-on-tags.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_push:
-    name: datagovuk-publish
+    name: datagovuk_publish
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/create-pr-on-tags.yaml
+++ b/.github/workflows/create-pr-on-tags.yaml
@@ -1,0 +1,22 @@
+name: Create charts PR on tags creation
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [ "Build and push images on tags" ]
+    types:
+      - completed
+
+jobs:
+  create_pr:
+    name: Create charts PR on tags creation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set GH_REF
+        run: echo "GH_REF=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`" >> $GITHUB_ENV
+      - run: bash ./docker/create-pr.sh
+        env:
+          GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}
+          IS_TAG: "true"
+          ENVS: "staging,production"


### PR DESCRIPTION
Description:
- Adds a GitHub action which opens a PR against the govuk-dgu-charts repository for the datagovuk_publish once build-image-on-tags is completed