### PR TITLE
Fix create-pr-on-tags to use k tag not v

### DIFF
--- a/.github/workflows/create-pr-on-tags.yaml
+++ b/.github/workflows/create-pr-on-tags.yaml
@@ -14,7 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set GH_REF
-        run: echo "GH_REF=`echo $(git fetch -t -q && git tag | sort --version-sort | tail -n1)`" >> $GITHUB_ENV
+        # Change back to git tag once we no longer need the k versions
+        run: echo "GH_REF=`echo $(git fetch -t -q && git tag -l "k*" | sort --version-sort | tail -n1)`" >> $GITHUB_ENV
       - run: bash ./docker/create-pr.sh
         env:
           GH_TOKEN: ${{ secrets.PR_GITHUB_TOKEN }}


### PR DESCRIPTION
Description:
- Currently the create-pr-on-tags action uses the latest 'v' version due to git tag. Changing this to `git tag -l "k*"` will let us use the `k` version
- Future PR will revert this back to `v` once we are satisfied the pipeline is working correctly