### PR TITLE
Log errors coming from elasticsearch indexing

### DIFF
--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -1,4 +1,5 @@
 require "elasticsearch/model"
+require "logger"
 require "securerandom"
 
 class Dataset < ApplicationRecord
@@ -36,6 +37,8 @@ class Dataset < ApplicationRecord
       result = __elasticsearch__.index_document(id: uuid)
       raise "Failed to publish" if result["_shards"]["failed"].positive?
     end
+  rescue StandardError => e
+    Rails.logger.error e
   end
 
   def unpublish
@@ -45,6 +48,8 @@ class Dataset < ApplicationRecord
     raise "Failed to unpublish" if result["_shards"]["failed"].positive?
 
     draft!
+  rescue StandardError => e
+    Rails.logger.error e
   end
 
   def as_indexed_json(_options = {})

--- a/spec/models/dataset_spec.rb
+++ b/spec/models/dataset_spec.rb
@@ -48,7 +48,7 @@ describe Dataset do
       allow(subject.__elasticsearch__).to receive(:index_document)
         .and_return("_shards" => { "failed" => 1 })
 
-      expect { subject.publish }.to raise_error(/Failed to publish/)
+      expect { subject.publish }.to_not raise_error(/Failed to publish/)
       expect(subject.reload.published?).to be_falsey
     end
   end
@@ -74,7 +74,7 @@ describe Dataset do
       allow(subject.__elasticsearch__).to receive(:delete_document)
         .and_return("_shards" => { "failed" => 1 })
 
-      expect { subject.unpublish }.to raise_error(/Failed to unpublish/)
+      expect { subject.unpublish }.to_not raise_error(/Failed to unpublish/)
       expect(subject.published?).to be_truthy
     end
   end


### PR DESCRIPTION
Most of the errors coming from the elasticsearch indexing are coming from bad data which we have little control over as it is managed by external publishers, so log the errors rather than raising them to stop Sentry being flooded by these validation errors.