### PR TITLE
Increase max deletions to 8000

### DIFF
--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 384
+      MAX_DELETIONS = 8000
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate


### PR DESCRIPTION
Allow max deletions to increase to 8000 to fix sync dataset sync issues on Integration and Staging.