### PR TITLE
Update MAX_SIZE deletion to 15647

### DIFF
--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 8000
+      MAX_DELETIONS = 15647
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate

--- a/app/lib/ckan/v26/depaginator.rb
+++ b/app/lib/ckan/v26/depaginator.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class Depaginator
       include CKAN::Modules::URLBuilder
-      MAX_DELETIONS = 15647
+      MAX_DELETIONS = 15_647
 
       def self.depaginate(*args, **kwargs)
         new(*args, **kwargs).depaginate


### PR DESCRIPTION
Delete 15647 records as one of the publishers wishes to remove all their datasets.