### PR TITLE
Fix inspire mapper harvest object

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -9,6 +9,7 @@ on:
         type: choice
         options:
           - build_push
+          - build_push_dev
           - build_only
   push:
     branches:
@@ -42,4 +43,11 @@ jobs:
         env:
           APP: datagovuk_publish
           ARCH: amd64
+        run: ./docker/build-image.sh
+      - name: Build and push dev images
+        if: ${{ inputs.buildType == 'build_push_dev' || github.ref == 'refs/heads/main' }}
+        env:
+          APP: datagovuk_publish
+          ARCH: amd64
+          DEV: "1"
         run: ./docker/build-image.sh

--- a/app/services/ckan/v26/inspire_mapper.rb
+++ b/app/services/ckan/v26/inspire_mapper.rb
@@ -11,7 +11,7 @@ module CKAN
           coupled_resource: package.get_extra("coupled-resource"),
           dataset_reference_date: package.get_extra("dataset-reference-date"),
           frequency_of_update: package.get_extra("frequency-of-update"),
-          harvest_object_id: package.get_extra("harvest_object_id") || package.get_harvest("harvest_object_id"),
+          harvest_object_id: package.get_harvest("harvest_object_id") || package.get_extra("harvest_object_id"),
           harvest_source_reference: package.get_extra("harvest_source_reference"),
           import_source: package.get_extra("import_source"),
           metadata_date: package.get_extra("metadata-date", 10),

--- a/docker/build-image.sh
+++ b/docker/build-image.sh
@@ -4,9 +4,9 @@ set -eux
 
 build () {
   if [ "${ARCH}" = "amd64" ]; then
-    docker build . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/Dockerfile"
+    docker build . -t "ghcr.io/alphagov/${APP}:${2}${1}" -f "docker/${2}Dockerfile"
   else
-    docker buildx build --platform "linux/${ARCH}" . -t "ghcr.io/alphagov/${APP}:${1}" -f "docker/Dockerfile"
+    docker buildx build --platform "linux/${ARCH}" . -t "ghcr.io/alphagov/${APP}:${2}${1}" -f "docker/${2}Dockerfile"
   fi
 }
 
@@ -16,10 +16,18 @@ if [[ -n ${GH_REF:-} ]]; then
   DOCKER_TAG="${GH_REF}"
 fi
 
-build "${DOCKER_TAG}"
+if [[ -n ${DEV:-} ]]; then
+  build "${DOCKER_TAG}" "dev."
+else
+  build "${DOCKER_TAG}" ""
+fi
 
 if [[ -n ${DRY_RUN:-} ]]; then
   echo "Dry run; not pushing to registry"
 else
-  docker push "ghcr.io/alphagov/${APP}:${DOCKER_TAG}"
+  if [[ -n ${DEV:-} ]]; then
+    docker push "ghcr.io/alphagov/${APP}:dev.${DOCKER_TAG}"
+  else
+    docker push "ghcr.io/alphagov/${APP}:${DOCKER_TAG}"
+  fi
 fi


### PR DESCRIPTION
The harvest object id from the harvest element in the CKAN response is more up to date than the harvest object id from extras so use that instead.

Also add in a way to build a dev image for debugging on the deployed cluster.