### PR TITLE
Do not retry for package import workers as it is run every 10 minutes anyway

### DIFF
--- a/app/workers/ckan/v26/package_import_worker.rb
+++ b/app/workers/ckan/v26/package_import_worker.rb
@@ -2,7 +2,7 @@ module CKAN
   module V26
     class PackageImportWorker
       include Sidekiq::Worker
-      sidekiq_options queue: :import, retry: 3 # Discarded after ~2 minutes
+      sidekiq_options queue: :import, retry: false
 
       def perform(package_id, *_args)
         package = get_package_from_ckan(package_id)


### PR DESCRIPTION
The publish worker is throwing errors when retrying a dead job so don't retry for package imports.