### PR TITLE
Ignore package import errors from 85f9f30b-4e09-4968-b24d-d4c68f17b9af

### DIFF
--- a/app/workers/ckan/v26/package_import_worker.rb
+++ b/app/workers/ckan/v26/package_import_worker.rb
@@ -9,7 +9,7 @@ module CKAN
         dataset = Dataset.find_or_initialize_by(uuid: package_id)
         update_dataset_from_package(package, dataset)
       rescue OpenURI::HTTPError
-        raise if Rails.env.production?
+        raise if Rails.env.production? && package_id != "85f9f30b-4e09-4968-b24d-d4c68f17b9af"
       end
 
     private


### PR DESCRIPTION
The ID doesn't appear to exist in the publish database, and as Publish will soon be removed from the stack just ignore errors from this ID